### PR TITLE
Adding caching and merging of configurations

### DIFF
--- a/consul.go
+++ b/consul.go
@@ -68,7 +68,7 @@ func NewConsulProvider() *ConsulProvider {
 	return consulProvider
 }
 
-func (provider *ConsulProvider) Provide(configurationChan chan<- *Configuration) {
+func (provider *ConsulProvider) Provide(configurationChan chan<- configMessage) {
 	config := &api.Config{
 		Address:    provider.Endpoint,
 		Scheme:     "http",
@@ -99,7 +99,7 @@ func (provider *ConsulProvider) Provide(configurationChan chan<- *Configuration)
 						waitIndex = meta.LastIndex
 						configuration := provider.loadConsulConfig()
 						if configuration != nil {
-							configurationChan <- configuration
+							configurationChan <- configMessage{"consul", configuration}
 						}
 					}
 				}
@@ -107,7 +107,7 @@ func (provider *ConsulProvider) Provide(configurationChan chan<- *Configuration)
 		}
 	}
 	configuration := provider.loadConsulConfig()
-	configurationChan <- configuration
+	configurationChan <- configMessage{"consul", configuration}
 }
 
 func (provider *ConsulProvider) loadConsulConfig() *Configuration {

--- a/docker.go
+++ b/docker.go
@@ -65,7 +65,7 @@ var DockerFuncMap = template.FuncMap{
 	"getHost": getHost,
 }
 
-func (provider *DockerProvider) Provide(configurationChan chan<- *Configuration) {
+func (provider *DockerProvider) Provide(configurationChan chan<- configMessage) {
 	if dockerClient, err := docker.NewClient(provider.Endpoint); err != nil {
 		log.Fatalf("Failed to create a client for docker, error: %s", err)
 	} else {
@@ -90,7 +90,7 @@ func (provider *DockerProvider) Provide(configurationChan chan<- *Configuration)
 							log.Debugf("Docker event receveived %+v", event)
 							configuration := provider.loadDockerConfig(dockerClient)
 							if configuration != nil {
-								configurationChan <- configuration
+								configurationChan <- configMessage{"docker", configuration}
 							}
 						}
 					}
@@ -106,7 +106,7 @@ func (provider *DockerProvider) Provide(configurationChan chan<- *Configuration)
 		}
 
 		configuration := provider.loadDockerConfig(dockerClient)
-		configurationChan <- configuration
+		configurationChan <- configMessage{"docker", configuration}
 	}
 }
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -254,83 +254,109 @@ $ curl -s "http://localhost:8080/health" | jq .
 }
 ```
 
-* ```/api```: ```GET``` or ```PUT``` a configuration
+* ```/api```: ```GET``` configuration for all providers
 
 ```sh
 $ curl -s "http://localhost:8082/api" | jq .
 {
-  "Frontends": {
-    "frontend-traefik": {
-      "Routes": {
-        "route-host-traefik": {
-          "Value": "traefik.docker.localhost",
-          "Rule": "Host"
-        }
+  "file": {
+    "Frontends": {
+      "frontend-traefik": {
+        "Routes": {
+          "route-host-traefik": {
+            "Value": "traefik.docker.localhost",
+            "Rule": "Host"
+          }
+        },
+        "Backend": "backend-test2"
       },
-      "Backend": "backend-test2"
+      "frontend-test": {
+        "Routes": {
+          "route-host-test": {
+            "Value": "test.docker.localhost",
+            "Rule": "Host"
+          }
+        },
+        "Backend": "backend-test1"
+      }
     },
-    "frontend-test": {
-      "Routes": {
-        "route-host-test": {
-          "Value": "test.docker.localhost",
-          "Rule": "Host"
+    "Backends": {
+      "backend-test2": {
+        "Servers": {
+          "server-stoic_brattain": {
+            "Weight": 0,
+            "Url": "http://172.17.0.8:80"
+          },
+          "server-jovial_khorana": {
+            "Weight": 0,
+            "Url": "http://172.17.0.12:80"
+          },
+          "server-jovial_franklin": {
+            "Weight": 0,
+            "Url": "http://172.17.0.11:80"
+          },
+          "server-elegant_panini": {
+            "Weight": 0,
+            "Url": "http://172.17.0.9:80"
+          },
+          "server-adoring_elion": {
+            "Weight": 0,
+            "Url": "http://172.17.0.10:80"
+          }
         }
       },
-      "Backend": "backend-test1"
+      "backend-test1": {
+        "Servers": {
+          "server-trusting_wozniak": {
+            "Weight": 0,
+            "Url": "http://172.17.0.5:80"
+          },
+          "server-sharp_jang": {
+            "Weight": 0,
+            "Url": "http://172.17.0.7:80"
+          },
+          "server-dreamy_feynman": {
+            "Weight": 0,
+            "Url": "http://172.17.0.6:80"
+          }
+        }
+      }
     }
   },
-  "Backends": {
-    "backend-test2": {
-      "Servers": {
-        "server-stoic_brattain": {
-          "Weight": 0,
-          "Url": "http://172.17.0.8:80"
+  "marathon": {
+    "Frontends": {
+      "frontend-marathon": {
+        "Routes": {
+          "route-host-marathon": {
+            "Value": "marathon.docker.localhost",
+            "Rule": "Host"
+          }
         },
-        "server-jovial_khorana": {
-          "Weight": 0,
-          "Url": "http://172.17.0.12:80"
-        },
-        "server-jovial_franklin": {
-          "Weight": 0,
-          "Url": "http://172.17.0.11:80"
-        },
-        "server-elegant_panini": {
-          "Weight": 0,
-          "Url": "http://172.17.0.9:80"
-        },
-        "server-adoring_elion": {
-          "Weight": 0,
-          "Url": "http://172.17.0.10:80"
-        }
-      }
+        "Backend": "backend-marathon"
+      },
     },
-    "backend-test1": {
-      "Servers": {
-        "server-trusting_wozniak": {
-          "Weight": 0,
-          "Url": "http://172.17.0.5:80"
+    "Backends": {
+      "backend-marathon": {
+        "Servers": {
+          "server-marathon-1": {
+            "Weight": 0,
+            "Url": "http://172.17.0.8:802"
+          },
         },
-        "server-sharp_jang": {
-          "Weight": 0,
-          "Url": "http://172.17.0.7:80"
-        },
-        "server-dreamy_feynman": {
-          "Weight": 0,
-          "Url": "http://172.17.0.6:80"
-        }
-      }
-    }
-  }
+      },
+    },
+  },
 }
 
 ```
 
-* ```/api/backends```: ```GET``` backends
-* ```/api/backends/{backend}```: ```GET``` a backend
-* ```/api/backends/{backend}/servers```: ```GET``` servers in a backend
-* ```/api/backends/{backend}/servers/{server}```: ```GET``` a server in a backend
-* ```/api/frontends```: ```GET``` frontends
-* ```/api/frontends/{frontend}```: ```GET``` a frontend
+* ```/api/{provider}```: ```GET``` or ```PUT``` provider
+* ```/api/{provider}/backends```: ```GET``` backends
+* ```/api/{provider}/backends/{backend}```: ```GET``` a backend
+* ```/api/{provider}/backends/{backend}/servers```: ```GET``` servers in a backend
+* ```/api/{provider}/backends/{backend}/servers/{server}```: ```GET``` a server in a backend
+* ```/api/{provider}/frontends```: ```GET``` frontends
+* ```/api/{provider}/frontends/{frontend}```: ```GET``` a frontend
 
 
 ## <a id="docker"></a> Docker backend

--- a/file.go
+++ b/file.go
@@ -23,7 +23,7 @@ func NewFileProvider() *FileProvider {
 	return fileProvider
 }
 
-func (provider *FileProvider) Provide(configurationChan chan<- *Configuration) {
+func (provider *FileProvider) Provide(configurationChan chan<- configMessage) {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		log.Error("Error creating file watcher", err)
@@ -48,7 +48,7 @@ func (provider *FileProvider) Provide(configurationChan chan<- *Configuration) {
 					log.Debug("File event:", event)
 					configuration := provider.LoadFileConfig(file.Name())
 					if configuration != nil {
-						configurationChan <- configuration
+						configurationChan <- configMessage{"file", configuration}
 					}
 				}
 			case error := <-watcher.Errors:
@@ -67,7 +67,7 @@ func (provider *FileProvider) Provide(configurationChan chan<- *Configuration) {
 	}
 
 	configuration := provider.LoadFileConfig(file.Name())
-	configurationChan <- configuration
+	configurationChan <- configMessage{"file", configuration}
 	<-done
 }
 

--- a/marathon.go
+++ b/marathon.go
@@ -67,7 +67,7 @@ var MarathonFuncMap = template.FuncMap{
 	},
 }
 
-func (provider *MarathonProvider) Provide(configurationChan chan<- *Configuration) {
+func (provider *MarathonProvider) Provide(configurationChan chan<- configMessage) {
 	config := marathon.NewDefaultConfig()
 	config.URL = provider.Endpoint
 	config.EventsInterface = provider.NetworkInterface
@@ -88,7 +88,7 @@ func (provider *MarathonProvider) Provide(configurationChan chan<- *Configuratio
 					log.Debug("Marathon event receveived", event)
 					configuration := provider.loadMarathonConfig()
 					if configuration != nil {
-						configurationChan <- configuration
+						configurationChan <- configMessage{"marathon", configuration}
 					}
 				}
 			}()
@@ -96,7 +96,7 @@ func (provider *MarathonProvider) Provide(configurationChan chan<- *Configuratio
 	}
 
 	configuration := provider.loadMarathonConfig()
-	configurationChan <- configuration
+	configurationChan <- configMessage{"marathon", configuration}
 }
 
 func (provider *MarathonProvider) loadMarathonConfig() *Configuration {

--- a/provider.go
+++ b/provider.go
@@ -1,5 +1,5 @@
 package main
 
 type Provider interface {
-	Provide(configurationChan chan<- *Configuration)
+	Provide(configurationChan chan<- configMessage)
 }

--- a/templates/configuration.tmpl
+++ b/templates/configuration.tmpl
@@ -27,9 +27,10 @@
     <div class="col-md-6">
         <!-- <div class="panel-heading">Frontends</div>
         <div class="panel-body"> -->
-            {{range $keyFrontends, $valueFrontends := .Configuration.Frontends}}
+            {{range $keyProviders, $valueProviders := .Configurations}}
+            {{range $keyFrontends, $valueFrontends := $valueProviders.Frontends}}
             <div class="panel panel-primary">
-                <div class="panel-heading">{{$keyFrontends}}</div>
+              <div class="panel-heading">{{$keyFrontends}} - ({{$keyProviders}})</div>
                 <div class="panel-body">
                     <a class="btn btn-info" role="button" data-toggle="collapse" href="#{{$valueFrontends.Backend}}" aria-expanded="false">
                         {{$valueFrontends.Backend}}
@@ -51,14 +52,16 @@
                 </table>
             </div>
             {{end}}
+            {{end}}
         <!-- </div> -->
     </div>
         <div class="col-md-6">
             <!-- <div class="panel-heading">Backends</div>
             <div class="panel-body"> -->
-                {{range $keyBackends, $valueBackends := .Configuration.Backends}}
+            {{range $keyProviders, $valueProviders := .Configurations}}
+                {{range $keyBackends, $valueBackends := $valueProviders.Backends}}
                 <div class="panel panel-primary" id="{{$keyBackends}}">
-                    <div class="panel-heading">{{$keyBackends}}</div>
+                  <div class="panel-heading">{{$keyBackends}}({{$keyProviders}})</div>
                     <div class="panel-body">
                         {{with $valueBackends.LoadBalancer}}
                         <a class="btn btn-info" role="button">
@@ -86,6 +89,7 @@
                         {{end}}
                     </table>
                 </div>
+                {{end}}
                 {{end}}
             <!-- </div> -->
         </div>

--- a/web.go
+++ b/web.go
@@ -145,13 +145,9 @@ func GetServerHandler(rw http.ResponseWriter, r *http.Request) {
 	providerId := vars["provider"]
 	backendId := vars["backend"]
 	serverId := vars["server"]
-	fmt.Printf("%v %v %v\n", providerId, backendId, serverId)
 	if provider, ok := currentConfigurations[providerId]; ok {
-		fmt.Printf("provider OK\n")
 		if backend, ok := provider.Backends[backendId]; ok {
-			fmt.Printf("backend OK\n")
 			if server, ok := backend.Servers[serverId]; ok {
-				fmt.Printf("server OK\n")
 				templatesRenderer.JSON(rw, http.StatusOK, server)
 				return
 			}

--- a/web.go
+++ b/web.go
@@ -83,55 +83,79 @@ func GetHealthHandler(rw http.ResponseWriter, r *http.Request) {
 
 func GetBackendsHandler(rw http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
-	templatesRenderer.JSON(rw, http.StatusOK, currentConfigurations[vars["provider"]].Backends)
+	providerId := vars["provider"]
+	if provider, ok := currentConfigurations[providerId]; ok {
+		templatesRenderer.JSON(rw, http.StatusOK, provider.Backends)
+	} else {
+		http.NotFound(rw, r)
+	}
 }
 
 func GetBackendHandler(rw http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
-	id := vars["backend"]
-	if backend, ok := currentConfigurations[vars["provider"]].Backends[id]; ok {
-		templatesRenderer.JSON(rw, http.StatusOK, backend)
-	} else {
-		http.NotFound(rw, r)
+	providerId := vars["provider"]
+	backendId := vars["backend"]
+	if provider, ok := currentConfigurations[providerId]; ok {
+		if backend, ok := provider.Backends[backendId]; ok {
+			templatesRenderer.JSON(rw, http.StatusOK, backend)
+			return
+		}
 	}
+	http.NotFound(rw, r)
 }
 
 func GetFrontendsHandler(rw http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
-	templatesRenderer.JSON(rw, http.StatusOK, currentConfigurations[vars["provider"]].Frontends)
+	providerId := vars["provider"]
+	if provider, ok := currentConfigurations[providerId]; ok {
+		templatesRenderer.JSON(rw, http.StatusOK, provider.Frontends)
+	} else {
+		http.NotFound(rw, r)
+	}
 }
 
 func GetFrontendHandler(rw http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
-	id := vars["frontend"]
-	if frontend, ok := currentConfigurations[vars["provider"]].Frontends[id]; ok {
-		templatesRenderer.JSON(rw, http.StatusOK, frontend)
-	} else {
-		http.NotFound(rw, r)
+	providerId := vars["provider"]
+	frontendId := vars["frontend"]
+	if provider, ok := currentConfigurations[providerId]; ok {
+		if frontend, ok := provider.Frontends[frontendId]; ok {
+			templatesRenderer.JSON(rw, http.StatusOK, frontend)
+			return
+		}
 	}
+	http.NotFound(rw, r)
 }
 
 func GetServersHandler(rw http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
-	backend := vars["backend"]
-	if backend, ok := currentConfigurations[vars["provider"]].Backends[backend]; ok {
-		templatesRenderer.JSON(rw, http.StatusOK, backend.Servers)
-	} else {
-		http.NotFound(rw, r)
+	providerId := vars["provider"]
+	backendId := vars["backend"]
+	if provider, ok := currentConfigurations[providerId]; ok {
+		if backend, ok := provider.Backends[backendId]; ok {
+			templatesRenderer.JSON(rw, http.StatusOK, backend.Servers)
+			return
+		}
 	}
+	http.NotFound(rw, r)
 }
 
 func GetServerHandler(rw http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
-	backend := vars["backend"]
-	server := vars["server"]
-	if backend, ok := currentConfigurations[vars["provider"]].Backends[backend]; ok {
-		if server, ok := backend.Servers[server]; ok {
-			templatesRenderer.JSON(rw, http.StatusOK, server)
-		} else {
-			http.NotFound(rw, r)
+	providerId := vars["provider"]
+	backendId := vars["backend"]
+	serverId := vars["server"]
+	fmt.Printf("%v %v %v\n", providerId, backendId, serverId)
+	if provider, ok := currentConfigurations[providerId]; ok {
+		fmt.Printf("provider OK\n")
+		if backend, ok := provider.Backends[backendId]; ok {
+			fmt.Printf("backend OK\n")
+			if server, ok := backend.Servers[serverId]; ok {
+				fmt.Printf("server OK\n")
+				templatesRenderer.JSON(rw, http.StatusOK, server)
+				return
+			}
 		}
-	} else {
-		http.NotFound(rw, r)
 	}
+	http.NotFound(rw, r)
 }

--- a/web.go
+++ b/web.go
@@ -35,6 +35,7 @@ func (provider *WebProvider) Provide(configurationChan chan<- configMessage) {
 			b, _ := ioutil.ReadAll(r.Body)
 			err := json.Unmarshal(b, configuration)
 			if err == nil {
+				webConfiguration = configuration
 				configurationChan <- configMessage{"web", configuration}
 				GetConfigHandler(rw, r)
 			} else {


### PR DESCRIPTION
Configurations are now cached from each provider separately so that
we can merge them together when one provider has changed config.

The Web module also returns full config info through the HTML call,
but REST API is working on a separate web configuration that is
sent in just like any other.