### PR TITLE
Add govet target and script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,10 +32,13 @@ test-integration: build
 	$(DOCKER_RUN_TRAEFIK) ./script/make.sh generate binary test-integration
 
 validate: build
-	$(DOCKER_RUN_TRAEFIK) ./script/make.sh validate-gofmt
+	$(DOCKER_RUN_TRAEFIK) ./script/make.sh validate-gofmt validate-govet
 
 validate-gofmt: build
 	$(DOCKER_RUN_TRAEFIK) ./script/make.sh validate-gofmt
+
+validate-govet: build
+	$(DOCKER_RUN_TRAEFIK) ./script/make.sh validate-govet
 
 build: dist
 	docker build -t "$(TRAEFIK_DEV_IMAGE)" -f build.Dockerfile .

--- a/script/validate-govet
+++ b/script/validate-govet
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+source "$(dirname "$BASH_SOURCE")/.validate"
+
+IFS=$'\n'
+files=( $(validate_diff --diff-filter=ACMR --name-only -- '*.go' | grep -v '^Godeps/' || true) )
+unset IFS
+
+errors=()
+for f in "${files[@]}"; do
+	# we use "git show" here to validate that what's committed passes go vet
+	failedVet=$(go tool vet -printf=false "$f")
+	if [ "$failedVet" ]; then
+		errors+=( "$failedVet" )
+	fi
+done
+
+if [ ${#errors[@]} -eq 0 ]; then
+	echo 'Congratulations!  All Go source files have been vetted.'
+else
+	{
+		echo "Errors from govet:"
+		for err in "${errors[@]}"; do
+			echo "$err"
+		done
+		echo
+		echo 'Please fix the above errors. You can test via "go vet" and commit the result.'
+		echo
+	} >&2
+	false
+fi


### PR DESCRIPTION
Adds a `go tool vet` check on changed files for `make validate`. It's possible to run the targe `make validate-govet` to check for it.

Because of `go-logging`, I had to put a `-printf=false` :sweat_smile:.

Rationale (taken from docker/docker#14756) : 
> - We want to improve code quality
> - We need objective filters on quality to help us discriminate bad pull requests

This is one of them :stuck_out_tongue:.

Signed-off-by: Vincent Demeester <vincent@sbr.pm>