### PR TITLE
Add getPrefixes to get string array of PathPrefixes

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -413,6 +413,7 @@ Labels can be used on containers to override default behaviour:
 * ```traefik.weight=10```: assign this weight to the application
 * ```traefik.enable=false```: disable this application in Træfɪk
 * ```traefik.host=bar```: override the default routing from {appName}.{domain} to bar.{domain}
+* ```traefik.prefixes=pf1,pf2```: use PathPrefix(es) instead of hostname for routing, use filename="providerTemplates/marathon-prefix.tmpl" with this option
 
 ## <a id="consul"></a> Consul backend
 

--- a/marathon.go
+++ b/marathon.go
@@ -53,6 +53,14 @@ var MarathonFuncMap = template.FuncMap{
 		}
 		return "0"
 	},
+	"getPrefixes": func(application marathon.Application) ([]string, error) {
+		for key, value := range application.Labels {
+			if key == "traefik.prefixes" {
+				return strings.Split(value, ","), nil
+			}
+		}
+		return []string{}, nil
+	},
 	"replace": func(s1 string, s2 string, s3 string) string {
 		return strings.Replace(s3, s1, s2, -1)
 	},

--- a/providerTemplates/marathon-prefix.tmpl
+++ b/providerTemplates/marathon-prefix.tmpl
@@ -1,0 +1,27 @@
+{{$apps := .Applications}}
+[backends]{{range .Tasks}}
+    [backends.backend{{.AppID | replace "/" "-"}}.servers.server-{{.ID | replace "." "-"}}]
+    url = "http://{{.Host}}:{{getPort .}}"
+    {{$appID := .AppID}}
+    {{range $apps}}
+    {{if eq $appID .ID}}
+    weight = {{getWeight .}}
+    {{end}}
+    {{end}}
+{{end}}
+
+[frontends]{{ range $app := .Applications}}
+  {{range $prefix := getPrefixes .}}
+  [frontends.frontend{{$app.ID | replace "/" "-"}}{{$prefix | replace "/" "-"}}]
+  backend = "backend{{$app.ID | replace "/" "-"}}"
+    [frontends.frontend-{{getHost $app | replace "/" "-"}}{{$prefix | replace "/" "-"}}.routes.route-prefix{{$prefix | replace "/" "-"}}]
+    rule = "PathPrefix"
+    value = "{{.}}"
+    {{else}}
+  [frontends.frontend{{.ID | replace "/" "-"}}]
+  backend = "backend{{.ID | replace "/" "-"}}"
+    [frontends.frontend-{{getHost $app | replace "/" "-"}}.routes.route-host-{{getHost $app | replace "/" "-"}}]
+    rule = "Host"
+    value = "{{getHost $app | replace "/" "-"}}.{{$.Domain}}"
+    {{end}}
+{{end}}


### PR DESCRIPTION
Marathon label traefik.prefixes can be used to specify what
prefixes to use.

New example marathon-prefix.tmpl to take advantage of this new
mechanism.