### PR TITLE
Corrects release management with build number in tags

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -30,5 +30,5 @@ deployment:
       - ghr -t $GITHUB_TOKEN -u $CIRCLE_PROJECT_USERNAME -r $CIRCLE_PROJECT_REPONAME --prerelease v1.0.alpha.$CIRCLE_BUILD_NUM dist/
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
       - docker push ${REPO,,}:latest
-      - docker tag ${REPO,,}:latest ${REPO,,}:$CIRCLE_SHA1
-      - docker push ${REPO,,}:$CIRCLE_SHA1
+      - docker tag ${REPO,,}:latest ${REPO,,}:v1.0.alpha.$CIRCLE_BUILD_NUM
+      - docker push ${REPO,,}:v1.0.alpha.$CIRCLE_BUILD_NUM

--- a/circle.yml
+++ b/circle.yml
@@ -27,7 +27,7 @@ deployment:
   hub:
     branch: master
     commands:
-      - ghr -t $GITHUB_TOKEN -u $CIRCLE_PROJECT_USERNAME -r $CIRCLE_PROJECT_REPONAME --replace --prerelease v1.0 dist/
+      - ghr -t $GITHUB_TOKEN -u $CIRCLE_PROJECT_USERNAME -r $CIRCLE_PROJECT_REPONAME --prerelease v1.0.alpha.$CIRCLE_BUILD_NUM dist/
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
       - docker push ${REPO,,}:latest
       - docker tag ${REPO,,}:latest ${REPO,,}:$CIRCLE_SHA1


### PR DESCRIPTION
The idea is to have releases tagged with v1.0.alpha.$CIRCLE_BUILD_NUM.