### PR TITLE
Carry Add backend throttle duration #48

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -3,23 +3,25 @@ package main
 import (
 	"errors"
 	"strings"
+	"time"
 )
 
 type GlobalConfiguration struct {
-	Port              string
-	GraceTimeOut      int64
-	AccessLogsFile    string
-	TraefikLogsFile   string
-	CertFile, KeyFile string
-	LogLevel          string
-	Docker            *DockerProvider
-	File              *FileProvider
-	Web               *WebProvider
-	Marathon          *MarathonProvider
-	Consul            *ConsulProvider
-	Etcd              *EtcdProvider
-	Zookeeper         *ZookepperProvider
-	Boltdb            *BoltDbProvider
+	Port                     string
+	GraceTimeOut             int64
+	AccessLogsFile           string
+	TraefikLogsFile          string
+	CertFile, KeyFile        string
+	LogLevel                 string
+	BackendsThrottleDuration time.Duration
+	Docker                   *DockerProvider
+	File                     *FileProvider
+	Web                      *WebProvider
+	Marathon                 *MarathonProvider
+	Consul                   *ConsulProvider
+	Etcd                     *EtcdProvider
+	Zookeeper                *ZookepperProvider
+	Boltdb                   *BoltDbProvider
 }
 
 func NewGlobalConfiguration() *GlobalConfiguration {
@@ -28,6 +30,7 @@ func NewGlobalConfiguration() *GlobalConfiguration {
 	globalConfiguration.Port = ":80"
 	globalConfiguration.GraceTimeOut = 10
 	globalConfiguration.LogLevel = "ERROR"
+	globalConfiguration.BackendsThrottleDuration = time.Duration(2 * time.Second)
 
 	return globalConfiguration
 }

--- a/configuration.go
+++ b/configuration.go
@@ -7,21 +7,21 @@ import (
 )
 
 type GlobalConfiguration struct {
-	Port                     string
-	GraceTimeOut             int64
-	AccessLogsFile           string
-	TraefikLogsFile          string
-	CertFile, KeyFile        string
-	LogLevel                 string
-	BackendsThrottleDuration time.Duration
-	Docker                   *DockerProvider
-	File                     *FileProvider
-	Web                      *WebProvider
-	Marathon                 *MarathonProvider
-	Consul                   *ConsulProvider
-	Etcd                     *EtcdProvider
-	Zookeeper                *ZookepperProvider
-	Boltdb                   *BoltDbProvider
+	Port                      string
+	GraceTimeOut              int64
+	AccessLogsFile            string
+	TraefikLogsFile           string
+	CertFile, KeyFile         string
+	LogLevel                  string
+	ProvidersThrottleDuration time.Duration
+	Docker                    *DockerProvider
+	File                      *FileProvider
+	Web                       *WebProvider
+	Marathon                  *MarathonProvider
+	Consul                    *ConsulProvider
+	Etcd                      *EtcdProvider
+	Zookeeper                 *ZookepperProvider
+	Boltdb                    *BoltDbProvider
 }
 
 func NewGlobalConfiguration() *GlobalConfiguration {
@@ -30,7 +30,7 @@ func NewGlobalConfiguration() *GlobalConfiguration {
 	globalConfiguration.Port = ":80"
 	globalConfiguration.GraceTimeOut = 10
 	globalConfiguration.LogLevel = "ERROR"
-	globalConfiguration.BackendsThrottleDuration = time.Duration(2 * time.Second)
+	globalConfiguration.ProvidersThrottleDuration = time.Duration(2 * time.Second)
 
 	return globalConfiguration
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -115,7 +115,7 @@ For example:
 # Optional
 # Default: "2s"
 #
-# BackendsThrottleDuration = "5s"
+# ProvidersThrottleDuration = "5s"
 
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -107,6 +107,16 @@ For example:
 #
 # CertFile = "traefik.crt"
 # KeyFile = "traefik.key"
+
+# Backends throttle duration: minimum duration between 2 events from providers
+# before applying a new configuration. It avoids unnecessary reloads if multiples events
+# are sent in a short amount of time.
+#
+# Optional
+# Default: "2s"
+#
+# BackendsThrottleDuration = "5s"
+
 ```
 
 

--- a/integration/marathon_test.go
+++ b/integration/marathon_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (s *MarathonSuite) TestSimpleConfiguration(c *check.C) {
-	cmd := exec.Command(traefikBinary, "fixtures/consul/simple.toml")
+	cmd := exec.Command(traefikBinary, "fixtures/marathon/simple.toml")
 	err := cmd.Start()
 	c.Assert(err, checker.IsNil)
 
@@ -18,7 +18,7 @@ func (s *MarathonSuite) TestSimpleConfiguration(c *check.C) {
 	// TODO validate : run on 80
 	resp, err := http.Get("http://127.0.0.1/")
 
-	// Expected a 404 as we did not comfigure anything
+	// Expected a 404 as we did not configure anything
 	c.Assert(err, checker.IsNil)
 	c.Assert(resp.StatusCode, checker.Equals, 404)
 

--- a/traefik.go
+++ b/traefik.go
@@ -104,15 +104,15 @@ func main() {
 			configMsg := <-configurationChan
 			log.Infof("Configuration receveived from provider %s: %#v", configMsg.providerName, configMsg.configuration)
 			lastConfigs[configMsg.providerName] = &configMsg
-			if time.Now().After(lastReceivedConfiguration.Add(time.Duration(globalConfiguration.BackendsThrottleDuration))) {
-				log.Infof("Last %s config received more than %s, OK", configMsg.providerName, globalConfiguration.BackendsThrottleDuration)
+			if time.Now().After(lastReceivedConfiguration.Add(time.Duration(globalConfiguration.ProvidersThrottleDuration))) {
+				log.Infof("Last %s config received more than %s, OK", configMsg.providerName, globalConfiguration.ProvidersThrottleDuration)
 				// last config received more than n s ago
 				configurationChanValidated <- configMsg
 			} else {
-				log.Infof("Last %s config received less than %s, waiting...", configMsg.providerName, globalConfiguration.BackendsThrottleDuration)
+				log.Infof("Last %s config received less than %s, waiting...", configMsg.providerName, globalConfiguration.ProvidersThrottleDuration)
 				go func() {
-					<-time.After(globalConfiguration.BackendsThrottleDuration)
-					if time.Now().After(lastReceivedConfiguration.Add(time.Duration(globalConfiguration.BackendsThrottleDuration))) {
+					<-time.After(globalConfiguration.ProvidersThrottleDuration)
+					if time.Now().After(lastReceivedConfiguration.Add(time.Duration(globalConfiguration.ProvidersThrottleDuration))) {
 						log.Infof("Waited for %s config, OK", configMsg.providerName)
 						configurationChanValidated <- *lastConfigs[configMsg.providerName]
 					}
@@ -124,7 +124,6 @@ func main() {
 	go func() {
 		for {
 			configMsg := <-configurationChanValidated
-			log.Debugf("Configuration %s", spew.Sdump(configMsg.configuration))
 			if configMsg.configuration == nil {
 				log.Info("Skipping empty configuration")
 			} else if reflect.DeepEqual(currentConfigurations[configMsg.providerName], configMsg.configuration) {

--- a/traefik.sample.toml
+++ b/traefik.sample.toml
@@ -51,7 +51,7 @@
 # Optional
 # Default: "2s"
 #
-# BackendsThrottleDuration = "5s"
+# ProvidersThrottleDuration = "5s"
 
 
 ################################################################

--- a/traefik.sample.toml
+++ b/traefik.sample.toml
@@ -44,6 +44,16 @@
 # CertFile = "traefik.crt"
 # KeyFile = "traefik.key"
 
+# Backends throttle duration: minimum duration between 2 events from providers
+# before applying a new configuration. It avoids unnecessary reloads if multiples events
+# are sent in a short amount of time.
+#
+# Optional
+# Default: "2s"
+#
+# BackendsThrottleDuration = "5s"
+
+
 ################################################################
 # Web configuration backend
 ################################################################


### PR DESCRIPTION
Closes #48.
Closes #46.

> This PR adds a backend throttle duration. It resolves #46
Backends throttle duration is the minimum duration between 2 events from providers before applying a new configuration. It avoids unnecessary reloads if multiples events are sent in a short amount of time.