### PR TITLE
Pass websocket headers to backend

### DIFF
--- a/middlewares/websocketproxy.go
+++ b/middlewares/websocketproxy.go
@@ -100,6 +100,9 @@ func (w *WebsocketProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	for _, cookie := range req.Header[http.CanonicalHeaderKey("Cookie")] {
 		requestHeader.Add("Cookie", cookie)
 	}
+	for _, auth := range req.Header[http.CanonicalHeaderKey("Authorization")] {
+		requestHeader.Add("Authorization", auth)
+	}
 
 	// Pass X-Forwarded-For headers too, code below is a part of
 	// httputil.ReverseProxy. See http://en.wikipedia.org/wiki/X-Forwarded-For
@@ -123,13 +126,16 @@ func (w *WebsocketProxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		requestHeader.Set("X-Forwarded-Proto", "https")
 	}
 
+	//frontend Origin != backend Origin
+	requestHeader.Del("Origin")
+
 	// Connect to the backend URL, also pass the headers we get from the requst
 	// together with the Forwarded headers we prepared above.
 	// TODO: support multiplexing on the same backend connection instead of
 	// opening a new TCP connection time for each request. This should be
 	// optional:
 	// http://tools.ietf.org/html/draft-ietf-hybi-websocket-multiplexing-01
-	connBackend, resp, err := dialer.Dial(backendURL.String(), nil)
+	connBackend, resp, err := dialer.Dial(backendURL.String(), requestHeader)
 	if err != nil {
 		log.Printf("websocketproxy: couldn't dial to remote backend url %s, %s, %+v", backendURL.String(), err, resp)
 		return


### PR DESCRIPTION
Changes:

* Include `Authorization` in websocket proxy headers
* Delete `Origin` as the frontend will differ to the backend (I guess we could set it backend origin instead?)
* Pass the request headers to the backend (Was there a reason it was previously `nil`?)

I needed this change for two reasons:
* https://github.com/jpillora/cloud-torrent uses basic auth ontop of websockets
* https://github.com/yudai/gotty uses a custom protocol which responds correctly only when this custom protocol (`Sec-WebSocket-Protocol`) is in the backend request