### PR TITLE
Add .dockerignore to lightweight build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+dist/
+vendor/
+!dist/traefik


### PR DESCRIPTION
Ignoring `vendor/` and `dist/`

Signed-off-by: Vincent Demeester <vincent@sbr.pm>