### PR TITLE
Add passhostheader in frontends configuration 

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -66,8 +66,9 @@ type Route struct {
 
 // Frontend configuration
 type Frontend struct {
-	Backend string           `json:"backend,omitempty"`
-	Routes  map[string]Route `json:"routes,omitempty"`
+	PassHostHeader bool             `json:"passHostHeader,omitempty"`
+	Backend        string           `json:"backend,omitempty"`
+	Routes         map[string]Route `json:"routes,omitempty"`
 }
 
 // Configuration of a provider

--- a/docker.go
+++ b/docker.go
@@ -106,6 +106,12 @@ func (provider *DockerProvider) loadDockerConfig(dockerClient *docker.Client) *C
 			}
 			return "http"
 		},
+		"getPassHostHeader": func(container docker.Container) string {
+			if passHostHeader, err := provider.getLabel(container, "traefik.frontend.passHostHeader"); err == nil {
+				return passHostHeader
+			}
+			return "false"
+		},
 		"getFrontendValue": provider.GetFrontendValue,
 		"getFrontendRule":  provider.GetFrontendRule,
 		"replace": func(s1 string, s2 string, s3 string) string {

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,6 +38,7 @@ Frontends can be defined using the following rules:
 
 
  A frontend is a set of rules that forwards the incoming http traffic to a backend.
+ You can optionally enable `passHostHeader` to forward client `Host` header to the backend.
 
 ### HTTP Backends
 
@@ -163,6 +164,7 @@ logLevel = "DEBUG"
     value = "test.localhost"
   [frontends.frontend2]
   backend = "backend1"
+  passHostHeader = true
     [frontends.frontend2.routes.test_2]
     rule = "Path"
     value = "/test"
@@ -210,6 +212,7 @@ filename = "rules.toml"
     value = "test.localhost"
   [frontends.frontend2]
   backend = "backend1"
+  passHostHeader = true
     [frontends.frontend2.routes.test_2]
     rule = "Path"
     value = "/test"
@@ -412,6 +415,7 @@ Labels can be used on containers to override default behaviour:
 - `traefik.enable=false`: disable this container in Træfɪk
 - `traefik.frontend.rule=Host`: override the default frontend rule (Default: Host). See [frontends](#frontends).
 - `traefik.frontend.value=test.example.com`: override the default frontend value (Default: `{containerName}.{domain}`) See [frontends](#frontends).
+- `traefik.frontend.passHostHeader=true`: forward client `Host` header to the backend.
 * `traefik.domain=traefik.localhost`: override the default domain
 
 
@@ -474,6 +478,7 @@ Labels can be used on containers to override default behaviour:
 - `traefik.enable=false`: disable this application in Træfɪk
 - `traefik.frontend.rule=Host`: override the default frontend rule (Default: Host). See [frontends](#frontends).
 - `traefik.frontend.value=test.example.com`: override the default frontend value (Default: `{appName}.{domain}`) See [frontends](#frontends).
+- `traefik.frontend.passHostHeader=true`: forward client `Host` header to the backend.
 * `traefik.domain=traefik.localhost`: override the default domain
 
 ## <a id="consul"></a> Consul backend
@@ -551,6 +556,7 @@ The Keys-Values structure should look (using `prefix = "/traefik"`):
 | Key                                                | Value      |
 |----------------------------------------------------|------------|
 | `/traefik/frontends/frontend2/backend`             | `backend1` |
+| `/traefik/frontends/frontend2/passHostHeader`      | `true`     |
 | `/traefik/frontends/frontend2/routes/test_2/rule`  | `Path`     |
 | `/traefik/frontends/frontend2/routes/test_2/value` | `/test`    |
 
@@ -630,6 +636,7 @@ The Keys-Values structure should look (using `prefix = "/traefik"`):
 | Key                                                | Value      |
 |----------------------------------------------------|------------|
 | `/traefik/frontends/frontend2/backend`             | `backend1` |
+| `/traefik/frontends/frontend2/passHostHeader`      | `true`     |
 | `/traefik/frontends/frontend2/routes/test_2/rule`  | `Path`     |
 | `/traefik/frontends/frontend2/routes/test_2/value` | `/test`    |
 
@@ -708,6 +715,7 @@ The Keys-Values structure should look (using `prefix = "/traefik"`):
 | Key                                                | Value      |
 |----------------------------------------------------|------------|
 | `/traefik/frontends/frontend2/backend`             | `backend1` |
+| `/traefik/frontends/frontend2/passHostHeader`      | `true`     |
 | `/traefik/frontends/frontend2/routes/test_2/rule`  | `Path`     |
 | `/traefik/frontends/frontend2/routes/test_2/value` | `/test`    |
 

--- a/marathon.go
+++ b/marathon.go
@@ -94,6 +94,12 @@ func (provider *MarathonProvider) loadMarathonConfig() *Configuration {
 			}
 			return "http"
 		},
+		"getPassHostHeader": func(application marathon.Application) string {
+			if passHostHeader, err := provider.getLabel(application, "traefik.frontend.passHostHeader"); err == nil {
+				return passHostHeader
+			}
+			return "false"
+		},
 		"getFrontendValue": provider.GetFrontendValue,
 		"getFrontendRule":  provider.GetFrontendRule,
 	}

--- a/static/app/sections/providers/frontend-monitor/frontend-monitor.html
+++ b/static/app/sections/providers/frontend-monitor/frontend-monitor.html
@@ -18,5 +18,6 @@
   </div>
   <div data-bg-show="frontendCtrl.frontend.backend" class="panel-footer">
     <span class="label label-warning" role="button" data-toggle="collapse" href="#{{frontendCtrl.frontend.backend}}" aria-expanded="false">{{frontendCtrl.frontend.backend}}</span>
+    <span data-ng-show="frontendCtrl.frontend.passHostHeader" class="label label-warning">Pass Host Header</span>
   </div>
 </div>

--- a/templates/docker.tmpl
+++ b/templates/docker.tmpl
@@ -7,6 +7,7 @@
 [frontends]{{range $frontend, $containers := .Frontends}}
   [frontends."frontend-{{$frontend}}"]{{$container := index $containers 0}}
   backend = "backend-{{getBackend $container}}"
+  passHostHeader = {{getPassHostHeader $container}}
     [frontends."frontend-{{$frontend}}".routes."route-frontend-{{$frontend}}"]
     rule = "{{getFrontendRule $container}}"
     value = "{{getFrontendValue $container}}"

--- a/templates/marathon.tmpl
+++ b/templates/marathon.tmpl
@@ -8,6 +8,7 @@
 [frontends]{{range .Applications}}
   [frontends.frontend{{.ID | replace "/" "-"}}]
   backend = "backend{{.ID | replace "/" "-"}}"
+  passHostHeader = {{getPassHostHeader .}}
     [frontends.frontend-{{.ID | replace "/" ""}}.routes.route-host-{{.ID | replace "/" ""}}]
     rule = "{{getFrontendRule .}}"
     value = "{{getFrontendValue .}}"

--- a/traefik.go
+++ b/traefik.go
@@ -287,7 +287,7 @@ func LoadConfig(configurations configs, globalConfiguration *GlobalConfiguration
 	for _, configuration := range configurations {
 		for frontendName, frontend := range configuration.Frontends {
 			log.Debugf("Creating frontend %s", frontendName)
-			fwd, _ := forward.New(forward.Logger(oxyLogger))
+			fwd, _ := forward.New(forward.Logger(oxyLogger), forward.PassHostHeader(frontend.PassHostHeader))
 			newRoute := router.NewRoute().Name(frontendName)
 			for routeName, route := range frontend.Routes {
 				log.Debugf("Creating route %s %s:%s", routeName, route.Rule, route.Value)

--- a/traefik.sample.toml
+++ b/traefik.sample.toml
@@ -356,6 +356,7 @@
 #     value = "test.localhost"
 #   [frontends.frontend2]
 #   backend = "backend1"
+#   passHostHeader = true
 #     [frontends.frontend2.routes.test_2]
 #     rule = "Path"
 #     value = "/test"


### PR DESCRIPTION
This PR:

- adds `passHostHeader` in frontend configuration
- adds `passHostHeader` in UI
- adds `traefik.frontend.passHostHeader` label in docker and marathon

Fixes #86 