### PR TITLE
Refactor traefik with package

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -1,9 +1,10 @@
 package main
 
 import (
-	"errors"
-	"strings"
 	"time"
+
+	"github.com/emilevauge/traefik/provider"
+	"github.com/emilevauge/traefik/types"
 )
 
 type GlobalConfiguration struct {
@@ -14,14 +15,14 @@ type GlobalConfiguration struct {
 	CertFile, KeyFile         string
 	LogLevel                  string
 	ProvidersThrottleDuration time.Duration
-	Docker                    *DockerProvider
-	File                      *FileProvider
+	Docker                    *provider.DockerProvider
+	File                      *provider.FileProvider
 	Web                       *WebProvider
-	Marathon                  *MarathonProvider
-	Consul                    *ConsulProvider
-	Etcd                      *EtcdProvider
-	Zookeeper                 *ZookepperProvider
-	Boltdb                    *BoltDbProvider
+	Marathon                  *provider.MarathonProvider
+	Consul                    *provider.ConsulProvider
+	Etcd                      *provider.EtcdProvider
+	Zookeeper                 *provider.ZookepperProvider
+	Boltdb                    *provider.BoltDbProvider
 }
 
 func NewGlobalConfiguration() *GlobalConfiguration {
@@ -35,79 +36,4 @@ func NewGlobalConfiguration() *GlobalConfiguration {
 	return globalConfiguration
 }
 
-// Backend configuration
-type Backend struct {
-	Servers        map[string]Server `json:"servers,omitempty"`
-	CircuitBreaker *CircuitBreaker   `json:"circuitBreaker,omitempty"`
-	LoadBalancer   *LoadBalancer     `json:"loadBalancer,omitempty"`
-}
-
-// LoadBalancer configuration
-type LoadBalancer struct {
-	Method string `json:"method,omitempty"`
-}
-
-// CircuitBreaker configuration
-type CircuitBreaker struct {
-	Expression string `json:"expression,omitempty"`
-}
-
-// Server configuration
-type Server struct {
-	URL    string `json:"url,omitempty"`
-	Weight int    `json:"weight,omitempty"`
-}
-
-// Route configuration
-type Route struct {
-	Rule  string `json:"rule,omitempty"`
-	Value string `json:"value,omitempty"`
-}
-
-// Frontend configuration
-type Frontend struct {
-	PassHostHeader bool             `json:"passHostHeader,omitempty"`
-	Backend        string           `json:"backend,omitempty"`
-	Routes         map[string]Route `json:"routes,omitempty"`
-}
-
-// Configuration of a provider
-type Configuration struct {
-	Backends  map[string]*Backend  `json:"backends,omitempty"`
-	Frontends map[string]*Frontend `json:"frontends,omitempty"`
-}
-
-// Load Balancer Method
-type LoadBalancerMethod uint8
-
-const (
-	// wrr (default) = Weighted Round Robin
-	wrr LoadBalancerMethod = iota
-	// drr = Dynamic Round Robin
-	drr
-)
-
-var loadBalancerMethodNames = []string{
-	"wrr",
-	"drr",
-}
-
-func NewLoadBalancerMethod(loadBalancer *LoadBalancer) (LoadBalancerMethod, error) {
-	if loadBalancer != nil {
-		for i, name := range loadBalancerMethodNames {
-			if strings.EqualFold(name, loadBalancer.Method) {
-				return LoadBalancerMethod(i), nil
-			}
-		}
-	}
-	return wrr, ErrInvalidLoadBalancerMethod
-}
-
-var ErrInvalidLoadBalancerMethod = errors.New("Invalid method, using default")
-
-type configMessage struct {
-	providerName  string
-	configuration *Configuration
-}
-
-type configs map[string]*Configuration
+type configs map[string]*types.Configuration

--- a/configuration.go
+++ b/configuration.go
@@ -15,14 +15,14 @@ type GlobalConfiguration struct {
 	CertFile, KeyFile         string
 	LogLevel                  string
 	ProvidersThrottleDuration time.Duration
-	Docker                    *provider.DockerProvider
-	File                      *provider.FileProvider
+	Docker                    *provider.Docker
+	File                      *provider.File
 	Web                       *WebProvider
-	Marathon                  *provider.MarathonProvider
-	Consul                    *provider.ConsulProvider
-	Etcd                      *provider.EtcdProvider
-	Zookeeper                 *provider.ZookepperProvider
-	Boltdb                    *provider.BoltDbProvider
+	Marathon                  *provider.Marathon
+	Consul                    *provider.Consul
+	Etcd                      *provider.Etcd
+	Zookeeper                 *provider.Zookepper
+	Boltdb                    *provider.BoltDb
 }
 
 func NewGlobalConfiguration() *GlobalConfiguration {

--- a/file_test.go
+++ b/file_test.go
@@ -1,1 +1,0 @@
-package main

--- a/generate.go
+++ b/generate.go
@@ -3,7 +3,7 @@ Copyright
 */
 
 //go:generate rm -vf gen.go
-//go:generate go-bindata -o gen.go static/... templates/...
+//go:generate go-bindata -pkg autogen -o autogen/gen.go ./static/... ./templates/...
 
 //go:generate mkdir -p vendor/github.com/docker/docker/autogen/dockerversion
 //go:generate cp script/dockerversion vendor/github.com/docker/docker/autogen/dockerversion/dockerversion.go

--- a/generate.go
+++ b/generate.go
@@ -2,7 +2,7 @@
 Copyright
 */
 
-//go:generate rm -vf gen.go
+//go:generate rm -vf autogen/gen.go
 //go:generate go-bindata -pkg autogen -o autogen/gen.go ./static/... ./templates/...
 
 //go:generate mkdir -p vendor/github.com/docker/docker/autogen/dockerversion

--- a/provider.go
+++ b/provider.go
@@ -1,5 +1,0 @@
-package main
-
-type Provider interface {
-	Provide(configurationChan chan<- configMessage) error
-}

--- a/provider/boltdb.go
+++ b/provider/boltdb.go
@@ -1,4 +1,6 @@
-package main
+package provider
+
+import "github.com/emilevauge/traefik/types"
 
 type BoltDbProvider struct {
 	Watch      bool
@@ -8,7 +10,7 @@ type BoltDbProvider struct {
 	KvProvider *KvProvider
 }
 
-func (provider *BoltDbProvider) Provide(configurationChan chan<- configMessage) error {
+func (provider *BoltDbProvider) Provide(configurationChan chan<- types.ConfigMessage) error {
 	provider.KvProvider = NewBoltDbProvider(provider)
 	return provider.KvProvider.provide(configurationChan)
 }

--- a/provider/boltdb.go
+++ b/provider/boltdb.go
@@ -2,15 +2,15 @@ package provider
 
 import "github.com/emilevauge/traefik/types"
 
-type BoltDbProvider struct {
+type BoltDb struct {
 	Watch      bool
 	Endpoint   string
 	Prefix     string
 	Filename   string
-	KvProvider *KvProvider
+	KvProvider *Kv
 }
 
-func (provider *BoltDbProvider) Provide(configurationChan chan<- types.ConfigMessage) error {
+func (provider *BoltDb) Provide(configurationChan chan<- types.ConfigMessage) error {
 	provider.KvProvider = NewBoltDbProvider(provider)
 	return provider.KvProvider.provide(configurationChan)
 }

--- a/provider/consul.go
+++ b/provider/consul.go
@@ -1,4 +1,6 @@
-package main
+package provider
+
+import "github.com/emilevauge/traefik/types"
 
 type ConsulProvider struct {
 	Watch      bool
@@ -8,7 +10,7 @@ type ConsulProvider struct {
 	KvProvider *KvProvider
 }
 
-func (provider *ConsulProvider) Provide(configurationChan chan<- configMessage) error {
+func (provider *ConsulProvider) Provide(configurationChan chan<- types.ConfigMessage) error {
 	provider.KvProvider = NewConsulProvider(provider)
 	return provider.KvProvider.provide(configurationChan)
 }

--- a/provider/consul.go
+++ b/provider/consul.go
@@ -2,15 +2,15 @@ package provider
 
 import "github.com/emilevauge/traefik/types"
 
-type ConsulProvider struct {
+type Consul struct {
 	Watch      bool
 	Endpoint   string
 	Prefix     string
 	Filename   string
-	KvProvider *KvProvider
+	KvProvider *Kv
 }
 
-func (provider *ConsulProvider) Provide(configurationChan chan<- types.ConfigMessage) error {
+func (provider *Consul) Provide(configurationChan chan<- types.ConfigMessage) error {
 	provider.KvProvider = NewConsulProvider(provider)
 	return provider.KvProvider.provide(configurationChan)
 }

--- a/provider/docker.go
+++ b/provider/docker.go
@@ -18,14 +18,14 @@ import (
 	"github.com/fsouza/go-dockerclient"
 )
 
-type DockerProvider struct {
+type Docker struct {
 	Watch    bool
 	Endpoint string
 	Filename string
 	Domain   string
 }
 
-func (provider *DockerProvider) Provide(configurationChan chan<- types.ConfigMessage) error {
+func (provider *Docker) Provide(configurationChan chan<- types.ConfigMessage) error {
 	if dockerClient, err := docker.NewClient(provider.Endpoint); err != nil {
 		log.Errorf("Failed to create a client for docker, error: %s", err)
 		return err
@@ -73,7 +73,7 @@ func (provider *DockerProvider) Provide(configurationChan chan<- types.ConfigMes
 	return nil
 }
 
-func (provider *DockerProvider) loadDockerConfig(dockerClient *docker.Client) *types.Configuration {
+func (provider *Docker) loadDockerConfig(dockerClient *docker.Client) *types.Configuration {
 	var DockerFuncMap = template.FuncMap{
 		"getBackend": func(container docker.Container) string {
 			if label, err := provider.getLabel(container, "traefik.backend"); err == nil {
@@ -201,17 +201,17 @@ func (provider *DockerProvider) loadDockerConfig(dockerClient *docker.Client) *t
 	return configuration
 }
 
-func (provider *DockerProvider) getFrontendName(container docker.Container) string {
+func (provider *Docker) getFrontendName(container docker.Container) string {
 	// Replace '.' with '-' in quoted keys because of this issue https://github.com/BurntSushi/toml/issues/78
 	frontendName := fmt.Sprintf("%s-%s", provider.GetFrontendRule(container), provider.GetFrontendValue(container))
 	return strings.Replace(frontendName, ".", "-", -1)
 }
 
-func (provider *DockerProvider) getEscapedName(name string) string {
+func (provider *Docker) getEscapedName(name string) string {
 	return strings.Replace(name, "/", "", -1)
 }
 
-func (provider *DockerProvider) getLabel(container docker.Container, label string) (string, error) {
+func (provider *Docker) getLabel(container docker.Container, label string) (string, error) {
 	for key, value := range container.Config.Labels {
 		if key == label {
 			return value, nil
@@ -220,7 +220,7 @@ func (provider *DockerProvider) getLabel(container docker.Container, label strin
 	return "", errors.New("Label not found:" + label)
 }
 
-func (provider *DockerProvider) getLabels(container docker.Container, labels []string) (map[string]string, error) {
+func (provider *Docker) getLabels(container docker.Container, labels []string) (map[string]string, error) {
 	foundLabels := map[string]string{}
 	for _, label := range labels {
 		if foundLabel, err := provider.getLabel(container, label); err != nil {
@@ -232,14 +232,14 @@ func (provider *DockerProvider) getLabels(container docker.Container, labels []s
 	return foundLabels, nil
 }
 
-func (provider *DockerProvider) GetFrontendValue(container docker.Container) string {
+func (provider *Docker) GetFrontendValue(container docker.Container) string {
 	if label, err := provider.getLabel(container, "traefik.frontend.value"); err == nil {
 		return label
 	}
 	return provider.getEscapedName(container.Name) + "." + provider.Domain
 }
 
-func (provider *DockerProvider) GetFrontendRule(container docker.Container) string {
+func (provider *Docker) GetFrontendRule(container docker.Container) string {
 	if label, err := provider.getLabel(container, "traefik.frontend.rule"); err == nil {
 		return label
 	}

--- a/provider/etcd.go
+++ b/provider/etcd.go
@@ -2,15 +2,15 @@ package provider
 
 import "github.com/emilevauge/traefik/types"
 
-type EtcdProvider struct {
+type Etcd struct {
 	Watch      bool
 	Endpoint   string
 	Prefix     string
 	Filename   string
-	KvProvider *KvProvider
+	KvProvider *Kv
 }
 
-func (provider *EtcdProvider) Provide(configurationChan chan<- types.ConfigMessage) error {
+func (provider *Etcd) Provide(configurationChan chan<- types.ConfigMessage) error {
 	provider.KvProvider = NewEtcdProvider(provider)
 	return provider.KvProvider.provide(configurationChan)
 }

--- a/provider/etcd.go
+++ b/provider/etcd.go
@@ -1,4 +1,6 @@
-package main
+package provider
+
+import "github.com/emilevauge/traefik/types"
 
 type EtcdProvider struct {
 	Watch      bool
@@ -8,7 +10,7 @@ type EtcdProvider struct {
 	KvProvider *KvProvider
 }
 
-func (provider *EtcdProvider) Provide(configurationChan chan<- configMessage) error {
+func (provider *EtcdProvider) Provide(configurationChan chan<- types.ConfigMessage) error {
 	provider.KvProvider = NewEtcdProvider(provider)
 	return provider.KvProvider.provide(configurationChan)
 }

--- a/provider/file.go
+++ b/provider/file.go
@@ -11,12 +11,12 @@ import (
 	"gopkg.in/fsnotify.v1"
 )
 
-type FileProvider struct {
+type File struct {
 	Watch    bool
 	Filename string
 }
 
-func (provider *FileProvider) Provide(configurationChan chan<- types.ConfigMessage) error {
+func (provider *File) Provide(configurationChan chan<- types.ConfigMessage) error {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		log.Error("Error creating file watcher", err)
@@ -61,7 +61,7 @@ func (provider *FileProvider) Provide(configurationChan chan<- types.ConfigMessa
 	return nil
 }
 
-func (provider *FileProvider) LoadFileConfig(filename string) *types.Configuration {
+func (provider *File) LoadFileConfig(filename string) *types.Configuration {
 	configuration := new(types.Configuration)
 	if _, err := toml.DecodeFile(filename, configuration); err != nil {
 		log.Error("Error reading file:", err)

--- a/provider/file.go
+++ b/provider/file.go
@@ -1,4 +1,4 @@
-package main
+package provider
 
 import (
 	"os"
@@ -7,6 +7,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	log "github.com/Sirupsen/logrus"
+	"github.com/emilevauge/traefik/types"
 	"gopkg.in/fsnotify.v1"
 )
 
@@ -15,7 +16,7 @@ type FileProvider struct {
 	Filename string
 }
 
-func (provider *FileProvider) Provide(configurationChan chan<- configMessage) error {
+func (provider *FileProvider) Provide(configurationChan chan<- types.ConfigMessage) error {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		log.Error("Error creating file watcher", err)
@@ -40,7 +41,7 @@ func (provider *FileProvider) Provide(configurationChan chan<- configMessage) er
 						log.Debug("File event:", event)
 						configuration := provider.LoadFileConfig(file.Name())
 						if configuration != nil {
-							configurationChan <- configMessage{"file", configuration}
+							configurationChan <- types.ConfigMessage{"file", configuration}
 						}
 					}
 				case error := <-watcher.Errors:
@@ -56,12 +57,12 @@ func (provider *FileProvider) Provide(configurationChan chan<- configMessage) er
 	}
 
 	configuration := provider.LoadFileConfig(file.Name())
-	configurationChan <- configMessage{"file", configuration}
+	configurationChan <- types.ConfigMessage{"file", configuration}
 	return nil
 }
 
-func (provider *FileProvider) LoadFileConfig(filename string) *Configuration {
-	configuration := new(Configuration)
+func (provider *FileProvider) LoadFileConfig(filename string) *types.Configuration {
+	configuration := new(types.Configuration)
 	if _, err := toml.DecodeFile(filename, configuration); err != nil {
 		log.Error("Error reading file:", err)
 		return nil

--- a/provider/file_test.go
+++ b/provider/file_test.go
@@ -1,0 +1,1 @@
+package provider

--- a/provider/kv.go
+++ b/provider/kv.go
@@ -23,7 +23,7 @@ import (
 	"github.com/emilevauge/traefik/types"
 )
 
-type KvProvider struct {
+type Kv struct {
 	Watch     bool
 	Endpoint  string
 	Prefix    string
@@ -32,8 +32,8 @@ type KvProvider struct {
 	kvclient  store.Store
 }
 
-func NewConsulProvider(provider *ConsulProvider) *KvProvider {
-	kvProvider := new(KvProvider)
+func NewConsulProvider(provider *Consul) *Kv {
+	kvProvider := new(Kv)
 	kvProvider.Watch = provider.Watch
 	kvProvider.Endpoint = provider.Endpoint
 	kvProvider.Prefix = provider.Prefix
@@ -42,8 +42,8 @@ func NewConsulProvider(provider *ConsulProvider) *KvProvider {
 	return kvProvider
 }
 
-func NewEtcdProvider(provider *EtcdProvider) *KvProvider {
-	kvProvider := new(KvProvider)
+func NewEtcdProvider(provider *Etcd) *Kv {
+	kvProvider := new(Kv)
 	kvProvider.Watch = provider.Watch
 	kvProvider.Endpoint = provider.Endpoint
 	kvProvider.Prefix = provider.Prefix
@@ -52,8 +52,8 @@ func NewEtcdProvider(provider *EtcdProvider) *KvProvider {
 	return kvProvider
 }
 
-func NewZkProvider(provider *ZookepperProvider) *KvProvider {
-	kvProvider := new(KvProvider)
+func NewZkProvider(provider *Zookepper) *Kv {
+	kvProvider := new(Kv)
 	kvProvider.Watch = provider.Watch
 	kvProvider.Endpoint = provider.Endpoint
 	kvProvider.Prefix = provider.Prefix
@@ -62,8 +62,8 @@ func NewZkProvider(provider *ZookepperProvider) *KvProvider {
 	return kvProvider
 }
 
-func NewBoltDbProvider(provider *BoltDbProvider) *KvProvider {
-	kvProvider := new(KvProvider)
+func NewBoltDbProvider(provider *BoltDb) *Kv {
+	kvProvider := new(Kv)
 	kvProvider.Watch = provider.Watch
 	kvProvider.Endpoint = provider.Endpoint
 	kvProvider.Prefix = provider.Prefix
@@ -72,7 +72,7 @@ func NewBoltDbProvider(provider *BoltDbProvider) *KvProvider {
 	return kvProvider
 }
 
-func (provider *KvProvider) provide(configurationChan chan<- types.ConfigMessage) error {
+func (provider *Kv) provide(configurationChan chan<- types.ConfigMessage) error {
 	switch provider.StoreType {
 	case store.CONSUL:
 		consul.Register()
@@ -122,7 +122,7 @@ func (provider *KvProvider) provide(configurationChan chan<- types.ConfigMessage
 	return nil
 }
 
-func (provider *KvProvider) loadConfig() *types.Configuration {
+func (provider *Kv) loadConfig() *types.Configuration {
 	configuration := new(types.Configuration)
 	templateObjects := struct {
 		Prefix string

--- a/provider/marathon.go
+++ b/provider/marathon.go
@@ -1,15 +1,17 @@
-package main
+package provider
 
 import (
 	"bytes"
+	"errors"
 	"strconv"
 	"strings"
 	"text/template"
 
-	"errors"
 	"github.com/BurntSushi/toml"
 	"github.com/BurntSushi/ty/fun"
 	log "github.com/Sirupsen/logrus"
+	"github.com/emilevauge/traefik/autogen"
+	"github.com/emilevauge/traefik/types"
 	"github.com/gambol99/go-marathon"
 )
 
@@ -22,7 +24,7 @@ type MarathonProvider struct {
 	NetworkInterface string
 }
 
-func (provider *MarathonProvider) Provide(configurationChan chan<- configMessage) error {
+func (provider *MarathonProvider) Provide(configurationChan chan<- types.ConfigMessage) error {
 	config := marathon.NewDefaultConfig()
 	config.URL = provider.Endpoint
 	config.EventsInterface = provider.NetworkInterface
@@ -43,7 +45,7 @@ func (provider *MarathonProvider) Provide(configurationChan chan<- configMessage
 					log.Debug("Marathon event receveived", event)
 					configuration := provider.loadMarathonConfig()
 					if configuration != nil {
-						configurationChan <- configMessage{"marathon", configuration}
+						configurationChan <- types.ConfigMessage{"marathon", configuration}
 					}
 				}
 			}()
@@ -51,11 +53,11 @@ func (provider *MarathonProvider) Provide(configurationChan chan<- configMessage
 	}
 
 	configuration := provider.loadMarathonConfig()
-	configurationChan <- configMessage{"marathon", configuration}
+	configurationChan <- types.ConfigMessage{"marathon", configuration}
 	return nil
 }
 
-func (provider *MarathonProvider) loadMarathonConfig() *Configuration {
+func (provider *MarathonProvider) loadMarathonConfig() *types.Configuration {
 	var MarathonFuncMap = template.FuncMap{
 		"getPort": func(task marathon.Task) string {
 			for _, port := range task.Ports {
@@ -103,7 +105,7 @@ func (provider *MarathonProvider) loadMarathonConfig() *Configuration {
 		"getFrontendValue": provider.GetFrontendValue,
 		"getFrontendRule":  provider.GetFrontendRule,
 	}
-	configuration := new(Configuration)
+	configuration := new(types.Configuration)
 
 	applications, err := provider.marathonClient.Applications(nil)
 	if err != nil {
@@ -187,7 +189,7 @@ func (provider *MarathonProvider) loadMarathonConfig() *Configuration {
 			return nil
 		}
 	} else {
-		buf, err := Asset("templates/marathon.tmpl")
+		buf, err := autogen.Asset("templates/marathon.tmpl")
 		if err != nil {
 			log.Error("Error reading file", err)
 		}

--- a/provider/marathon.go
+++ b/provider/marathon.go
@@ -15,7 +15,7 @@ import (
 	"github.com/gambol99/go-marathon"
 )
 
-type MarathonProvider struct {
+type Marathon struct {
 	Watch            bool
 	Endpoint         string
 	marathonClient   marathon.Marathon
@@ -24,7 +24,7 @@ type MarathonProvider struct {
 	NetworkInterface string
 }
 
-func (provider *MarathonProvider) Provide(configurationChan chan<- types.ConfigMessage) error {
+func (provider *Marathon) Provide(configurationChan chan<- types.ConfigMessage) error {
 	config := marathon.NewDefaultConfig()
 	config.URL = provider.Endpoint
 	config.EventsInterface = provider.NetworkInterface
@@ -57,7 +57,7 @@ func (provider *MarathonProvider) Provide(configurationChan chan<- types.ConfigM
 	return nil
 }
 
-func (provider *MarathonProvider) loadMarathonConfig() *types.Configuration {
+func (provider *Marathon) loadMarathonConfig() *types.Configuration {
 	var MarathonFuncMap = template.FuncMap{
 		"getPort": func(task marathon.Task) string {
 			for _, port := range task.Ports {
@@ -225,7 +225,7 @@ func getApplication(task marathon.Task, apps []marathon.Application) (marathon.A
 	return marathon.Application{}, errors.New("Application not found: " + task.AppID)
 }
 
-func (provider *MarathonProvider) getLabel(application marathon.Application, label string) (string, error) {
+func (provider *Marathon) getLabel(application marathon.Application, label string) (string, error) {
 	for key, value := range application.Labels {
 		if key == label {
 			return value, nil
@@ -234,18 +234,18 @@ func (provider *MarathonProvider) getLabel(application marathon.Application, lab
 	return "", errors.New("Label not found:" + label)
 }
 
-func (provider *MarathonProvider) getEscapedName(name string) string {
+func (provider *Marathon) getEscapedName(name string) string {
 	return strings.Replace(name, "/", "", -1)
 }
 
-func (provider *MarathonProvider) GetFrontendValue(application marathon.Application) string {
+func (provider *Marathon) GetFrontendValue(application marathon.Application) string {
 	if label, err := provider.getLabel(application, "traefik.frontend.value"); err == nil {
 		return label
 	}
 	return provider.getEscapedName(application.ID) + "." + provider.Domain
 }
 
-func (provider *MarathonProvider) GetFrontendRule(application marathon.Application) string {
+func (provider *Marathon) GetFrontendRule(application marathon.Application) string {
 	if label, err := provider.getLabel(application, "traefik.frontend.rule"); err == nil {
 		return label
 	}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -1,0 +1,7 @@
+package provider
+
+import "github.com/emilevauge/traefik/types"
+
+type Provider interface {
+	Provide(configurationChan chan<- types.ConfigMessage) error
+}

--- a/provider/zk.go
+++ b/provider/zk.go
@@ -1,4 +1,6 @@
-package main
+package provider
+
+import "github.com/emilevauge/traefik/types"
 
 type ZookepperProvider struct {
 	Watch      bool
@@ -8,7 +10,7 @@ type ZookepperProvider struct {
 	KvProvider *KvProvider
 }
 
-func (provider *ZookepperProvider) Provide(configurationChan chan<- configMessage) error {
+func (provider *ZookepperProvider) Provide(configurationChan chan<- types.ConfigMessage) error {
 	provider.KvProvider = NewZkProvider(provider)
 	return provider.KvProvider.provide(configurationChan)
 }

--- a/provider/zk.go
+++ b/provider/zk.go
@@ -2,15 +2,15 @@ package provider
 
 import "github.com/emilevauge/traefik/types"
 
-type ZookepperProvider struct {
+type Zookepper struct {
 	Watch      bool
 	Endpoint   string
 	Prefix     string
 	Filename   string
-	KvProvider *KvProvider
+	KvProvider *Kv
 }
 
-func (provider *ZookepperProvider) Provide(configurationChan chan<- types.ConfigMessage) error {
+func (provider *Zookepper) Provide(configurationChan chan<- types.ConfigMessage) error {
 	provider.KvProvider = NewZkProvider(provider)
 	return provider.KvProvider.provide(configurationChan)
 }

--- a/script/binary
+++ b/script/binary
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-if ! test -e gen.go; then
+if ! test -e autogen/gen.go; then
 	echo >&2 'error: generate must be run before binary'
 	false
 fi

--- a/script/crossbinary
+++ b/script/crossbinary
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 
-if ! test -e gen.go; then
-	echo >&2 'error: generate must be run before binary'
+if ! test -e autogen/gen.go; then
+	echo >&2 'error: generate must be run before crossbinary'
 	false
 fi
 

--- a/script/test-unit
+++ b/script/test-unit
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 
-if ! test -e gen.go; then
-	echo >&2 'error: generate must be run before binary'
+if ! test -e autogen/gen.go; then
+	echo >&2 'error: generate must be run before test-unit'
 	false
 fi
 

--- a/types/types.go
+++ b/types/types.go
@@ -1,0 +1,81 @@
+package types
+
+import (
+	"errors"
+	"strings"
+)
+
+// Backend configuration
+type Backend struct {
+	Servers        map[string]Server `json:"servers,omitempty"`
+	CircuitBreaker *CircuitBreaker   `json:"circuitBreaker,omitempty"`
+	LoadBalancer   *LoadBalancer     `json:"loadBalancer,omitempty"`
+}
+
+// LoadBalancer configuration
+type LoadBalancer struct {
+	Method string `json:"method,omitempty"`
+}
+
+// CircuitBreaker configuration
+type CircuitBreaker struct {
+	Expression string `json:"expression,omitempty"`
+}
+
+// Server configuration
+type Server struct {
+	URL    string `json:"url,omitempty"`
+	Weight int    `json:"weight,omitempty"`
+}
+
+// Route configuration
+type Route struct {
+	Rule  string `json:"rule,omitempty"`
+	Value string `json:"value,omitempty"`
+}
+
+// Frontend configuration
+type Frontend struct {
+	Backend        string           `json:"backend,omitempty"`
+	Routes         map[string]Route `json:"routes,omitempty"`
+	PassHostHeader bool             `json:"passHostHeader,omitempty"`
+}
+
+// Load Balancer Method
+type LoadBalancerMethod uint8
+
+const (
+	// Wrr (default) = Weighted Round Robin
+	Wrr LoadBalancerMethod = iota
+	// Drr = Dynamic Round Robin
+	Drr
+)
+
+var loadBalancerMethodNames = []string{
+	"Wrr",
+	"Drr",
+}
+
+func NewLoadBalancerMethod(loadBalancer *LoadBalancer) (LoadBalancerMethod, error) {
+	if loadBalancer != nil {
+		for i, name := range loadBalancerMethodNames {
+			if strings.EqualFold(name, loadBalancer.Method) {
+				return LoadBalancerMethod(i), nil
+			}
+		}
+	}
+	return Wrr, ErrInvalidLoadBalancerMethod
+}
+
+var ErrInvalidLoadBalancerMethod = errors.New("Invalid method, using default")
+
+// Configuration of a provider
+type Configuration struct {
+	Backends  map[string]*Backend  `json:"backends,omitempty"`
+	Frontends map[string]*Frontend `json:"frontends,omitempty"`
+}
+
+type ConfigMessage struct {
+	ProviderName  string
+	Configuration *Configuration
+}

--- a/web.go
+++ b/web.go
@@ -8,6 +8,8 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/elazarl/go-bindata-assetfs"
+	"github.com/emilevauge/traefik/autogen"
+	"github.com/emilevauge/traefik/types"
 	"github.com/gorilla/mux"
 	"github.com/unrolled/render"
 )
@@ -23,7 +25,7 @@ var (
 	})
 )
 
-func (provider *WebProvider) Provide(configurationChan chan<- configMessage) error {
+func (provider *WebProvider) Provide(configurationChan chan<- types.ConfigMessage) error {
 	systemRouter := mux.NewRouter()
 
 	// health route
@@ -41,11 +43,11 @@ func (provider *WebProvider) Provide(configurationChan chan<- configMessage) err
 			return
 		}
 
-		configuration := new(Configuration)
+		configuration := new(types.Configuration)
 		body, _ := ioutil.ReadAll(request.Body)
 		err := json.Unmarshal(body, configuration)
 		if err == nil {
-			configurationChan <- configMessage{"web", configuration}
+			configurationChan <- types.ConfigMessage{"web", configuration}
 			getConfigHandler(response, request)
 		} else {
 			log.Errorf("Error parsing configuration %+v", err)
@@ -65,7 +67,7 @@ func (provider *WebProvider) Provide(configurationChan chan<- configMessage) err
 	systemRouter.Methods("GET").Path("/").HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		http.Redirect(response, request, "/dashboard/", 302)
 	})
-	systemRouter.Methods("GET").PathPrefix("/dashboard/").Handler(http.StripPrefix("/dashboard/", http.FileServer(&assetfs.AssetFS{Asset: Asset, AssetDir: AssetDir, Prefix: "static"})))
+	systemRouter.Methods("GET").PathPrefix("/dashboard/").Handler(http.StripPrefix("/dashboard/", http.FileServer(&assetfs.AssetFS{Asset: autogen.Asset, AssetDir: autogen.AssetDir, Prefix: "static"})))
 
 	go func() {
 		if len(provider.CertFile) > 0 && len(provider.KeyFile) > 0 {


### PR DESCRIPTION
Split a bit traefik into package. The idea behind this refactor is to start move inter-dependencies away and do some DRY or SRP or both :stuck_out_tongue_closed_eyes: . 🐙

- Adds a `provider` package, with providers except `web.go`
- Adds a `types` package with common struct.
- Move `gen.go` to an `autogen` package

The 2nd commit is *optional*, but will be needed at some point :see_no_evil:.
To test heavily as it might breaks things that are not covered yet :smile_cat:.

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>