### PR TITLE
Move version info in its own file.

### DIFF
--- a/traefik.go
+++ b/traefik.go
@@ -28,8 +28,6 @@ import (
 )
 
 var (
-	Version               = ""
-	BuildDate             = ""
 	globalConfigFile      = kingpin.Arg("conf", "Main configration file.").Default("traefik.toml").String()
 	version               = kingpin.Flag("version", "Get Version.").Short('v').Bool()
 	currentConfigurations = make(configs)

--- a/version.go
+++ b/version.go
@@ -1,0 +1,6 @@
+package main
+
+var (
+	Version   = ""
+	BuildDate = ""
+)


### PR DESCRIPTION
Just because.. why not ? I would even think we should move it to a `version` package. @emilevauge WDYT ?

Signed-off-by: Vincent Demeester <vincent@sbr.pm>