### PR TITLE
Remove go get go-bindata from generate.go

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ You need either [Docker](https://github.com/docker/docker) and `make`, or `go` a
 #### Setting up your `go` environment
 - You need `go` v1.5
 - You need to set `export GO15VENDOREXPERIMENT=1` environment variable
+- You need `go-bindata` to be able to use `go generate` command (needed to build) : `go get github.com/jteeuwen/go-bindata/...`.
 - If you clone Træfɪk into something like `~/go/src/github.com/traefik`, your `GOPATH` variable will have to be set to `~/go`: export `GOPATH=~/go`.
 
 #### Using `Docker` and `Makefile`

--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -3,6 +3,7 @@ FROM golang:1.5
 RUN go get github.com/Masterminds/glide
 RUN go get github.com/mitchellh/gox
 RUN go get github.com/tcnksm/ghr
+RUN go get github.com/jteeuwen/go-bindata/...
 
 # Which docker version to test on
 ENV DOCKER_VERSION 1.6.2

--- a/generate.go
+++ b/generate.go
@@ -2,7 +2,6 @@
 Copyright
 */
 
-//go:generate go get github.com/jteeuwen/go-bindata/...
 //go:generate rm -vf gen.go
 //go:generate go-bindata -o gen.go static/... templates/...
 


### PR DESCRIPTION
This mades the build impossible offline (as when doing a go generate it was trying to go get something)

Probably needs some documentation updates too (like do a `go get …`).. But I found it kinda bad to not be able to build `traefik` while offline, in the train :sweat_smile:.

Signed-off-by: Vincent Demeester <vincent@sbr.pm>