### PR TITLE
Linting some packages

### DIFF
--- a/middlewares/cbreaker.go
+++ b/middlewares/cbreaker.go
@@ -1,6 +1,3 @@
-/*
-Copyright
-*/
 package middlewares
 
 import (
@@ -9,10 +6,12 @@ import (
 	"github.com/mailgun/oxy/cbreaker"
 )
 
+// CircuitBreaker holds the oxy circuit breaker.
 type CircuitBreaker struct {
 	circuitBreaker *cbreaker.CircuitBreaker
 }
 
+// NewCircuitBreaker returns a new CircuitBreaker.
 func NewCircuitBreaker(next http.Handler, expression string, options ...cbreaker.CircuitBreakerOption) *CircuitBreaker {
 	circuitBreaker, _ := cbreaker.New(next, expression, options...)
 	return &CircuitBreaker{circuitBreaker}

--- a/middlewares/logger.go
+++ b/middlewares/logger.go
@@ -1,6 +1,3 @@
-/*
-Copyright
-*/
 package middlewares
 
 import (
@@ -16,7 +13,7 @@ type Logger struct {
 	file *os.File
 }
 
-// NewLogger returns a new Logger instance
+// NewLogger returns a new Logger instance.
 func NewLogger(file string) *Logger {
 	if len(file) > 0 {
 		fi, err := os.OpenFile(file, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
@@ -36,6 +33,7 @@ func (l *Logger) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.Ha
 	}
 }
 
+// Close closes the logger (i.e. the file).
 func (l *Logger) Close() {
 	l.file.Close()
 }

--- a/middlewares/routes.go
+++ b/middlewares/routes.go
@@ -1,6 +1,3 @@
-/*
-Copyright
-*/
 package middlewares
 
 import (
@@ -11,10 +8,12 @@ import (
 	"github.com/gorilla/mux"
 )
 
+// Routes holds the gorilla mux routes (for the API & co).
 type Routes struct {
 	router *mux.Router
 }
 
+// NewRoutes return a Routes based on the given router.
 func NewRoutes(router *mux.Router) *Routes {
 	return &Routes{router}
 }

--- a/middlewares/websocket.go
+++ b/middlewares/websocket.go
@@ -1,20 +1,20 @@
-/*
-Copyright
-*/
 package middlewares
 
 import (
-	log "github.com/Sirupsen/logrus"
-	"github.com/mailgun/oxy/roundrobin"
 	"net/http"
 	"strings"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/mailgun/oxy/roundrobin"
 )
 
+// WebsocketUpgrader holds Websocket configuration.
 type WebsocketUpgrader struct {
 	rr *roundrobin.RoundRobin
 }
 
+// NewWebsocketUpgrader returns a new WebsocketUpgrader.
 func NewWebsocketUpgrader(rr *roundrobin.RoundRobin) *WebsocketUpgrader {
 	wu := WebsocketUpgrader{
 		rr: rr,

--- a/provider/boltdb.go
+++ b/provider/boltdb.go
@@ -2,6 +2,7 @@ package provider
 
 import "github.com/emilevauge/traefik/types"
 
+// BoltDb holds configurations of the BoltDb provider.
 type BoltDb struct {
 	Watch      bool
 	Endpoint   string
@@ -10,6 +11,8 @@ type BoltDb struct {
 	KvProvider *Kv
 }
 
+// Provide allows the provider to provide configurations to traefik
+// using the given configuration channel.
 func (provider *BoltDb) Provide(configurationChan chan<- types.ConfigMessage) error {
 	provider.KvProvider = NewBoltDbProvider(provider)
 	return provider.KvProvider.provide(configurationChan)

--- a/provider/consul.go
+++ b/provider/consul.go
@@ -2,6 +2,7 @@ package provider
 
 import "github.com/emilevauge/traefik/types"
 
+// Consul holds configurations of the Consul provider.
 type Consul struct {
 	Watch      bool
 	Endpoint   string
@@ -10,6 +11,8 @@ type Consul struct {
 	KvProvider *Kv
 }
 
+// Provide allows the provider to provide configurations to traefik
+// using the given configuration channel.
 func (provider *Consul) Provide(configurationChan chan<- types.ConfigMessage) error {
 	provider.KvProvider = NewConsulProvider(provider)
 	return provider.KvProvider.provide(configurationChan)

--- a/provider/etcd.go
+++ b/provider/etcd.go
@@ -2,6 +2,7 @@ package provider
 
 import "github.com/emilevauge/traefik/types"
 
+// Etcd holds configurations of the Etcd provider.
 type Etcd struct {
 	Watch      bool
 	Endpoint   string
@@ -10,6 +11,8 @@ type Etcd struct {
 	KvProvider *Kv
 }
 
+// Provide allows the provider to provide configurations to traefik
+// using the given configuration channel.
 func (provider *Etcd) Provide(configurationChan chan<- types.ConfigMessage) error {
 	provider.KvProvider = NewEtcdProvider(provider)
 	return provider.KvProvider.provide(configurationChan)

--- a/provider/file.go
+++ b/provider/file.go
@@ -11,11 +11,14 @@ import (
 	"gopkg.in/fsnotify.v1"
 )
 
+// File holds configurations of the File provider.
 type File struct {
 	Watch    bool
 	Filename string
 }
 
+// Provide allows the provider to provide configurations to traefik
+// using the given configuration channel.
 func (provider *File) Provide(configurationChan chan<- types.ConfigMessage) error {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
@@ -39,7 +42,7 @@ func (provider *File) Provide(configurationChan chan<- types.ConfigMessage) erro
 				case event := <-watcher.Events:
 					if strings.Contains(event.Name, file.Name()) {
 						log.Debug("File event:", event)
-						configuration := provider.LoadFileConfig(file.Name())
+						configuration := provider.loadFileConfig(file.Name())
 						if configuration != nil {
 							configurationChan <- types.ConfigMessage{"file", configuration}
 						}
@@ -56,12 +59,12 @@ func (provider *File) Provide(configurationChan chan<- types.ConfigMessage) erro
 		}
 	}
 
-	configuration := provider.LoadFileConfig(file.Name())
+	configuration := provider.loadFileConfig(file.Name())
 	configurationChan <- types.ConfigMessage{"file", configuration}
 	return nil
 }
 
-func (provider *File) LoadFileConfig(filename string) *types.Configuration {
+func (provider *File) loadFileConfig(filename string) *types.Configuration {
 	configuration := new(types.Configuration)
 	if _, err := toml.DecodeFile(filename, configuration); err != nil {
 		log.Error("Error reading file:", err)

--- a/provider/kv.go
+++ b/provider/kv.go
@@ -1,6 +1,4 @@
-/*
-Copyright
-*/
+// Package provider holds the different provider implementation.
 package provider
 
 import (
@@ -23,6 +21,7 @@ import (
 	"github.com/emilevauge/traefik/types"
 )
 
+// Kv holds common configurations of key-value providers.
 type Kv struct {
 	Watch     bool
 	Endpoint  string
@@ -32,6 +31,7 @@ type Kv struct {
 	kvclient  store.Store
 }
 
+// NewConsulProvider returns a Consul provider.
 func NewConsulProvider(provider *Consul) *Kv {
 	kvProvider := new(Kv)
 	kvProvider.Watch = provider.Watch
@@ -42,6 +42,7 @@ func NewConsulProvider(provider *Consul) *Kv {
 	return kvProvider
 }
 
+// NewEtcdProvider returns a Etcd provider.
 func NewEtcdProvider(provider *Etcd) *Kv {
 	kvProvider := new(Kv)
 	kvProvider.Watch = provider.Watch
@@ -52,6 +53,7 @@ func NewEtcdProvider(provider *Etcd) *Kv {
 	return kvProvider
 }
 
+// NewZkProvider returns a Zookepper provider.
 func NewZkProvider(provider *Zookepper) *Kv {
 	kvProvider := new(Kv)
 	kvProvider.Watch = provider.Watch
@@ -62,6 +64,7 @@ func NewZkProvider(provider *Zookepper) *Kv {
 	return kvProvider
 }
 
+// NewBoltDbProvider returns a BoldDb provider.
 func NewBoltDbProvider(provider *BoltDb) *Kv {
 	kvProvider := new(Kv)
 	kvProvider.Watch = provider.Watch

--- a/provider/marathon.go
+++ b/provider/marathon.go
@@ -15,15 +15,18 @@ import (
 	"github.com/gambol99/go-marathon"
 )
 
+// Marathon holds configuration of the Marathon provider.
 type Marathon struct {
 	Watch            bool
 	Endpoint         string
-	marathonClient   marathon.Marathon
 	Domain           string
 	Filename         string
 	NetworkInterface string
+	marathonClient   marathon.Marathon
 }
 
+// Provide allows the provider to provide configurations to traefik
+// using the given configuration channel.
 func (provider *Marathon) Provide(configurationChan chan<- types.ConfigMessage) error {
 	config := marathon.NewDefaultConfig()
 	config.URL = provider.Endpoint
@@ -238,6 +241,8 @@ func (provider *Marathon) getEscapedName(name string) string {
 	return strings.Replace(name, "/", "", -1)
 }
 
+// GetFrontendValue returns the frontend value for the specified application, using
+// it's label. It returns a default one if the label is not present.
 func (provider *Marathon) GetFrontendValue(application marathon.Application) string {
 	if label, err := provider.getLabel(application, "traefik.frontend.value"); err == nil {
 		return label
@@ -245,6 +250,8 @@ func (provider *Marathon) GetFrontendValue(application marathon.Application) str
 	return provider.getEscapedName(application.ID) + "." + provider.Domain
 }
 
+// GetFrontendRule returns the frontend rule for the specified application, using
+// it's label. It returns a default one (Host) if the label is not present.
 func (provider *Marathon) GetFrontendRule(application marathon.Application) string {
 	if label, err := provider.getLabel(application, "traefik.frontend.rule"); err == nil {
 		return label

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -2,6 +2,9 @@ package provider
 
 import "github.com/emilevauge/traefik/types"
 
+// Provider defines methods of a provider.
 type Provider interface {
+	// Provide allows the provider to provide configurations to traefik
+	// using the given configuration channel.
 	Provide(configurationChan chan<- types.ConfigMessage) error
 }

--- a/provider/zk.go
+++ b/provider/zk.go
@@ -2,6 +2,7 @@ package provider
 
 import "github.com/emilevauge/traefik/types"
 
+// Zookepper holds configurations of the Zookepper provider.
 type Zookepper struct {
 	Watch      bool
 	Endpoint   string
@@ -10,6 +11,8 @@ type Zookepper struct {
 	KvProvider *Kv
 }
 
+// Provide allows the provider to provide configurations to traefik
+// using the given configuration channel.
 func (provider *Zookepper) Provide(configurationChan chan<- types.ConfigMessage) error {
 	provider.KvProvider = NewZkProvider(provider)
 	return provider.KvProvider.provide(configurationChan)

--- a/types/types.go
+++ b/types/types.go
@@ -5,43 +5,43 @@ import (
 	"strings"
 )
 
-// Backend configuration
+// Backend holds backend configuration.
 type Backend struct {
 	Servers        map[string]Server `json:"servers,omitempty"`
 	CircuitBreaker *CircuitBreaker   `json:"circuitBreaker,omitempty"`
 	LoadBalancer   *LoadBalancer     `json:"loadBalancer,omitempty"`
 }
 
-// LoadBalancer configuration
+// LoadBalancer holds load balancing configuration.
 type LoadBalancer struct {
 	Method string `json:"method,omitempty"`
 }
 
-// CircuitBreaker configuration
+// CircuitBreaker holds circuit breaker configuration.
 type CircuitBreaker struct {
 	Expression string `json:"expression,omitempty"`
 }
 
-// Server configuration
+// Server holds server configuration.
 type Server struct {
 	URL    string `json:"url,omitempty"`
 	Weight int    `json:"weight,omitempty"`
 }
 
-// Route configuration
+// Route holds route configuration.
 type Route struct {
 	Rule  string `json:"rule,omitempty"`
 	Value string `json:"value,omitempty"`
 }
 
-// Frontend configuration
+// Frontend holds frontend configuration.
 type Frontend struct {
 	Backend        string           `json:"backend,omitempty"`
 	Routes         map[string]Route `json:"routes,omitempty"`
 	PassHostHeader bool             `json:"passHostHeader,omitempty"`
 }
 
-// Load Balancer Method
+// LoadBalancerMethod holds the method of load balancing to use.
 type LoadBalancerMethod uint8
 
 const (
@@ -56,6 +56,7 @@ var loadBalancerMethodNames = []string{
 	"Drr",
 }
 
+// NewLoadBalancerMethod create a new LoadBalancerMethod from a given LoadBalancer.
 func NewLoadBalancerMethod(loadBalancer *LoadBalancer) (LoadBalancerMethod, error) {
 	if loadBalancer != nil {
 		for i, name := range loadBalancerMethodNames {
@@ -67,14 +68,16 @@ func NewLoadBalancerMethod(loadBalancer *LoadBalancer) (LoadBalancerMethod, erro
 	return Wrr, ErrInvalidLoadBalancerMethod
 }
 
+// ErrInvalidLoadBalancerMethod is thrown when the specified load balancing method is invalid.
 var ErrInvalidLoadBalancerMethod = errors.New("Invalid method, using default")
 
-// Configuration of a provider
+// Configuration of a provider.
 type Configuration struct {
 	Backends  map[string]*Backend  `json:"backends,omitempty"`
 	Frontends map[string]*Frontend `json:"frontends,omitempty"`
 }
 
+// ConfigMessage hold configuration information exchanged between parts of traefik.
 type ConfigMessage struct {
 	ProviderName  string
 	Configuration *Configuration


### PR DESCRIPTION
Following #88, *lint* some packages : `middlewares`, `provider` and `types` 🐼. 

This will ease the soon to be coming `script/validate-golint` script 😇.

🐸