### PR TITLE
Updates and additions on some integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,5 @@ log
 *.iml
 traefik
 traefik.toml
-
+*.test
 vendor/

--- a/integration/basic_test.go
+++ b/integration/basic_test.go
@@ -10,6 +10,9 @@ import (
 	check "gopkg.in/check.v1"
 )
 
+// SimpleSuite
+type SimpleSuite struct{ BaseSuite }
+
 func (s *SimpleSuite) TestNoOrInexistentConfigShouldFail(c *check.C) {
 	cmd := exec.Command(traefikBinary)
 	output, err := cmd.CombinedOutput()
@@ -37,6 +40,7 @@ func (s *SimpleSuite) TestSimpleDefaultConfig(c *check.C) {
 	cmd := exec.Command(traefikBinary, "fixtures/simple_default.toml")
 	err := cmd.Start()
 	c.Assert(err, checker.IsNil)
+	defer cmd.Process.Kill()
 
 	time.Sleep(500 * time.Millisecond)
 	// TODO validate : run on 80
@@ -45,7 +49,18 @@ func (s *SimpleSuite) TestSimpleDefaultConfig(c *check.C) {
 	// Expected a 404 as we did not comfigure anything
 	c.Assert(err, checker.IsNil)
 	c.Assert(resp.StatusCode, checker.Equals, 404)
+}
 
-	killErr := cmd.Process.Kill()
-	c.Assert(killErr, checker.IsNil)
+func (s *SimpleSuite) TestWithWebConfig(c *check.C) {
+	cmd := exec.Command(traefikBinary, "fixtures/simple_web.toml")
+	err := cmd.Start()
+	c.Assert(err, checker.IsNil)
+	defer cmd.Process.Kill()
+
+	time.Sleep(500 * time.Millisecond)
+
+	resp, err := http.Get("http://127.0.0.1:8080/api")
+	// Expected a 200
+	c.Assert(err, checker.IsNil)
+	c.Assert(resp.StatusCode, checker.Equals, 200)
 }

--- a/integration/consul_test.go
+++ b/integration/consul_test.go
@@ -13,6 +13,7 @@ func (s *ConsulSuite) TestSimpleConfiguration(c *check.C) {
 	cmd := exec.Command(traefikBinary, "fixtures/consul/simple.toml")
 	err := cmd.Start()
 	c.Assert(err, checker.IsNil)
+	defer cmd.Process.Kill()
 
 	time.Sleep(500 * time.Millisecond)
 	// TODO validate : run on 80
@@ -21,7 +22,4 @@ func (s *ConsulSuite) TestSimpleConfiguration(c *check.C) {
 	// Expected a 404 as we did not comfigure anything
 	c.Assert(err, checker.IsNil)
 	c.Assert(resp.StatusCode, checker.Equals, 404)
-
-	killErr := cmd.Process.Kill()
-	c.Assert(killErr, checker.IsNil)
 }

--- a/integration/file_test.go
+++ b/integration/file_test.go
@@ -13,6 +13,7 @@ func (s *FileSuite) TestSimpleConfiguration(c *check.C) {
 	cmd := exec.Command(traefikBinary, "fixtures/file/simple.toml")
 	err := cmd.Start()
 	c.Assert(err, checker.IsNil)
+	defer cmd.Process.Kill()
 
 	time.Sleep(500 * time.Millisecond)
 	resp, err := http.Get("http://127.0.0.1/")
@@ -20,9 +21,6 @@ func (s *FileSuite) TestSimpleConfiguration(c *check.C) {
 	// Expected a 404 as we did not configure anything
 	c.Assert(err, checker.IsNil)
 	c.Assert(resp.StatusCode, checker.Equals, 404)
-
-	killErr := cmd.Process.Kill()
-	c.Assert(killErr, checker.IsNil)
 }
 
 // #56 regression test, make sure it does not fail
@@ -30,6 +28,7 @@ func (s *FileSuite) TestSimpleConfigurationNoPanic(c *check.C) {
 	cmd := exec.Command(traefikBinary, "fixtures/file/56-simple-panic.toml")
 	err := cmd.Start()
 	c.Assert(err, checker.IsNil)
+	defer cmd.Process.Kill()
 
 	time.Sleep(500 * time.Millisecond)
 	resp, err := http.Get("http://127.0.0.1/")
@@ -37,7 +36,4 @@ func (s *FileSuite) TestSimpleConfigurationNoPanic(c *check.C) {
 	// Expected a 404 as we did not configure anything
 	c.Assert(err, checker.IsNil)
 	c.Assert(resp.StatusCode, checker.Equals, 404)
-
-	killErr := cmd.Process.Kill()
-	c.Assert(killErr, checker.IsNil)
 }

--- a/integration/fixtures/simple_web.toml
+++ b/integration/fixtures/simple_web.toml
@@ -1,0 +1,5 @@
+logLevel = "DEBUG"
+
+[web]
+
+address = ":8080"

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -32,9 +32,6 @@ func init() {
 
 var traefikBinary = "../dist/traefik"
 
-// SimpleSuite
-type SimpleSuite struct{ BaseSuite }
-
 // File test suites
 type FileSuite struct{ BaseSuite }
 

--- a/integration/marathon_test.go
+++ b/integration/marathon_test.go
@@ -13,6 +13,7 @@ func (s *MarathonSuite) TestSimpleConfiguration(c *check.C) {
 	cmd := exec.Command(traefikBinary, "fixtures/marathon/simple.toml")
 	err := cmd.Start()
 	c.Assert(err, checker.IsNil)
+	defer cmd.Process.Kill()
 
 	time.Sleep(500 * time.Millisecond)
 	// TODO validate : run on 80
@@ -21,7 +22,4 @@ func (s *MarathonSuite) TestSimpleConfiguration(c *check.C) {
 	// Expected a 404 as we did not configure anything
 	c.Assert(err, checker.IsNil)
 	c.Assert(resp.StatusCode, checker.Equals, 404)
-
-	killErr := cmd.Process.Kill()
-	c.Assert(killErr, checker.IsNil)
 }


### PR DESCRIPTION
- Use `defer` to kill traefik process (to fix the still running traefik binaries if the given tests is failing before the kill)
- Add `TestWithWebConfig`
- Add *.test to gitignore to ignore the test binaries generated by go.

After each *next* pass on the integration suite, I'll move the definition (`DockerSuite`, etc..) in their own files :wink:.

Signed-off-by: Vincent Demeester <vincent@sbr.pm>