### PR TITLE
Allow Docker to be load balanced

### DIFF
--- a/templates/docker.tmpl
+++ b/templates/docker.tmpl
@@ -1,14 +1,16 @@
-[backends]{{range .Containers}}
-    [backends.backend-{{getBackend .}}.servers.server-{{.Name | replace "/" "" | replace "." "-"}}]
-    url = "{{getProtocol .}}://{{.NetworkSettings.IPAddress}}:{{getPort .}}"
-    weight = {{getWeight .}}
+[backends]{{range $frontend, $containers := .Frontends}}
+  [backends.{{makeParsedUrl $frontend}}]{{range $containers}}
+    [backends.{{makeParsedUrl $frontend | replace "/" "" | replace "." "-"}}.servers.{{.Name | replace "/" "" | replace "." "-"}}]
+      url = "{{getProtocol .}}://{{.NetworkSettings.IPAddress}}:{{getPort .}}"
+      weight = {{getWeight .}}
+    {{end}}
 {{end}}
 
 [frontends]{{range $frontend, $containers := .Frontends}}
-  [frontends."frontend-{{$frontend}}"]{{$container := index $containers 0}}
-  backend = "backend-{{getBackend $container}}"
+  [frontends.{{makeParsedUrl $frontend}}]{{$container := index $containers 0}}
+  backend = "{{makeParsedUrl $frontend}}"
   passHostHeader = {{getPassHostHeader $container}}
-    [frontends."frontend-{{$frontend}}".routes."route-frontend-{{$frontend}}"]
-    rule = "{{getFrontendRule $container}}"
-    value = "{{getFrontendValue $container}}"
+    [frontends.{{makeParsedUrl $frontend | replace "/" "" | replace "." "-"}}.routes.{{makeParsedUrl $frontend | replace "/" "" | replace "." "-"}}]
+      rule = "{{getFrontendRule $container}}"
+      value = "{{getFrontendValue $container}}"
 {{end}}


### PR DESCRIPTION
I don't know the ultimate goal of things like the Docker support. Maybe my setup is completely wrong..

I did notice that when using Docker containers were not being load balanced as shown here:

![screen shot 2015-11-09 at 5 19 03 pm](https://cloud.githubusercontent.com/assets/2372558/11051096/6ea03814-8709-11e5-8e8c-3d59511fcf31.png)

If the container went away Traefik would properly fall back to the next available container but 100% of the traffic was being sent to one container.

With the changes that were made to the docker.tmpl it allows servers to be load balanced:

![screen shot 2015-11-09 at 5 15 08 pm](https://cloud.githubusercontent.com/assets/2372558/11051132/c22956b4-8709-11e5-9254-2066a977570b.png)

**Notes:**

 - The `makeParsedUrl` template function was a commit on a local branch in response to #98 . Happy to submit a PR on that too.
 - To get the frontends to work properly I had to drastically rename how the docker implementation was naming things.

Again, I could just be out here in left field but this now works for me.