### PR TITLE
Add filter task by running status in marathon

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -43,7 +43,7 @@ import:
   - package: github.com/alecthomas/units
     ref:     6b4e7dc5e3143b85ea77909c72caf89416fc2915
   - package: github.com/gambol99/go-marathon
-    ref:     0ba31bcb0d7633ba1888d744c42990eb15281cf1
+    ref:     8ce3f764250b2de3f2c627d12ca7dd21bd5e7f93
   - package: github.com/mailgun/predicate
     ref:     cb0bff91a7ab7cf7571e661ff883fc997bc554a3
   - package: github.com/thoas/stats
@@ -142,3 +142,8 @@ import:
   - package: github.com/codahale/hdrhistogram
     ref:     954f16e8b9ef0e5d5189456aa4c1202758e04f17
   - package: github.com/gorilla/websocket
+  - package: github.com/donovanhide/eventsource
+    ref:     d8a3071799b98cacd30b6da92f536050ccfe6da4
+  - package: github.com/golang/glog
+    ref:     fca8c8854093a154ff1eb580aae10276ad6b1b5f
+

--- a/provider/marathon.go
+++ b/provider/marathon.go
@@ -23,7 +23,7 @@ type Marathon struct {
 
 type lightMarathonClient interface {
 	Applications(url.Values) (*marathon.Applications, error)
-	AllTasks() (*marathon.Tasks, error)
+	AllTasks(v url.Values) (*marathon.Tasks, error)
 }
 
 // Provide allows the provider to provide configurations to traefik
@@ -85,7 +85,7 @@ func (provider *Marathon) loadMarathonConfig() *types.Configuration {
 		return nil
 	}
 
-	tasks, err := provider.marathonClient.AllTasks()
+	tasks, err := provider.marathonClient.AllTasks((url.Values{"status": []string{"running"}}))
 	if err != nil {
 		log.Errorf("Failed to create a client for marathon, error: %s", err)
 		return nil

--- a/provider/marathon_test.go
+++ b/provider/marathon_test.go
@@ -24,7 +24,7 @@ func (c *fakeClient) Applications(url.Values) (*marathon.Applications, error) {
 	return c.applications, nil
 }
 
-func (c *fakeClient) AllTasks() (*marathon.Tasks, error) {
+func (c *fakeClient) AllTasks(v url.Values) (*marathon.Tasks, error) {
 	if c.tasksError {
 		return nil, errors.New("error")
 	}


### PR DESCRIPTION
Newer version of go-marathon allows to get only `running` tasks.
https://github.com/gambol99/go-marathon/pull/82
Fixes #81 