### PR TITLE
Marathon tmpl converts slashes in Marathon app names to dashes

### DIFF
--- a/templates/marathon.tmpl
+++ b/templates/marathon.tmpl
@@ -9,7 +9,7 @@
   [frontends.frontend{{.ID | replace "/" "-"}}]
   backend = "backend{{.ID | replace "/" "-"}}"
   passHostHeader = {{getPassHostHeader .}}
-    [frontends.frontend-{{.ID | replace "/" ""}}.routes.route-host-{{.ID | replace "/" ""}}]
+    [frontends.frontend{{.ID | replace "/" "-"}}.routes.route-host{{.ID | replace "/" "-"}}]
     rule = "{{getFrontendRule .}}"
     value = "{{getFrontendValue .}}"
 {{end}}


### PR DESCRIPTION
Fixes #136, the included Marathon tmpl should convert multiple slashes in Marathon app names to dashes when creating route/backend.

Otherwise, apps such as /hello/world will cause Traefic to fail on startup.

```
time="2015-12-04T22:20:08Z" level=debug msg="Creating frontend frontend-helloworld"
time="2015-12-04T22:20:08Z" level=debug msg="Creating route route-host-helloworld Host: helloworld.mydomain"
time="2015-12-04T22:20:08Z" level=debug msg="Creating backend "
time="2015-12-04T22:20:08Z" level=error msg="Error loading new configuration, aborted Backend not found: "
```

After this change:

```
time="2015-12-05T18:07:36Z" level=debug msg="Creating frontend frontend-hello-world" 
time="2015-12-05T18:07:36Z" level=debug msg="Creating route route-host-hello-world Host:helloworld.mydomain" 
time="2015-12-05T18:07:36Z" level=debug msg="Creating backend backend-hello-world" 
time="2015-12-05T18:07:36Z" level=info msg="Creating load-balancer wrr" 
time="2015-12-05T18:07:36Z" level=info msg="Creating server server-hello_world-1042966b-9b7b-11e5-8b36-fa163ecb296c http://1.2.3.4:48922"
```
