### PR TITLE
Marathon provider uses port from label.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -487,7 +487,8 @@ domain = "marathon.localhost"
 Labels can be used on containers to override default behaviour:
 
 - `traefik.backend=foo`: assign the application to `foo` backend
-- `traefik.port=80`: register this port. Useful when the application exposes multiples ports.
+- `traefik.portIndex=1`: register port by index in the application's ports array. Useful when the application exposes multiple ports.
+- `traefik.port=80`: register the explicit application port value. Cannot be used alongside `traefik.portIndex`.
 - `traefik.protocol=https`: override the default `http` protocol
 - `traefik.weight=10`: assign this weight to the application
 - `traefik.enable=false`: disable this application in Træfɪk

--- a/templates/marathon.tmpl
+++ b/templates/marathon.tmpl
@@ -1,7 +1,7 @@
 {{$apps := .Applications}}
 [backends]{{range .Tasks}}
     [backends.backend{{.AppID | replace "/" "-"}}.servers.server-{{.ID | replace "." "-"}}]
-    url = "{{getProtocol . $apps}}://{{.Host}}:{{getPort .}}"
+    url = "{{getProtocol . $apps}}://{{.Host}}:{{getPort . $apps}}"
     weight = {{getWeight . $apps}}
 {{end}}
 


### PR DESCRIPTION
The "traefik.port" label value is not used when selecting which port to use. Instead, the Marathon provider always uses the first possible port.

The Marathon provider should honor the "traefik.port" label supplied by the Marathon app.  If no "traefik.port" label is specified, then the first possible port us used.
