### PR TITLE
Add minimal systemd service file

### DIFF
--- a/contrib/systemd/traefik.service
+++ b/contrib/systemd/traefik.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Traefik
+
+[Service]
+ExecStart=/usr/bin/traefik /etc/traefik.toml
+Restart=on-failure


### PR DESCRIPTION
The super simple traefik service I'm using. It assumes the binary has been installed as /usr/bin/traefik