### PR TITLE
Glide up quick

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,14 +115,14 @@ traefik*
 
 The idea behind `glide` is the following :
 
-- when checkout(ing) a project, **run `glide up`** to install
+- when checkout(ing) a project, **run `glide up --quick`** to install
   (`go get …`) the dependencies in the `GOPATH`.
 - if you need another dependency, import and use it in
   the source, and **run `glide get github.com/Masterminds/cookoo`** to save it in
   `vendor` and add it to your `glide.yaml`.
 
 ```bash
-$ glide up --update-vendored
+$ glide up --quick
 # generate
 $ go generate
 # Simple go build

--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -23,6 +23,6 @@ RUN ln -s /usr/local/bin/docker-${DOCKER_VERSION} /usr/local/bin/docker
 WORKDIR /go/src/github.com/emilevauge/traefik
 
 COPY glide.yaml glide.yaml
-RUN glide up
+RUN glide up --quick
 
 COPY . /go/src/github.com/emilevauge/traefik

--- a/glide.yaml
+++ b/glide.yaml
@@ -136,7 +136,7 @@ import:
   - package: gopkg.in/fsnotify.v1
     ref:     96c060f6a6b7e0d6f75fddd10efeaca3e5d1bcb0
   - package: github.com/mailgun/manners
-    ref:     37136f736785d7c6aa3b9a27b4b2dd1028ca6d79
+    ref:     fada45142db3f93097ca917da107aa3fad0ffcb5
   - package: github.com/gorilla/context
     ref:     215affda49addc4c8ef7e2534915df2c8c35c6cd
   - package: github.com/codahale/hdrhistogram


### PR DESCRIPTION
This PR add `--quick` to `glide up`.
Fixes the issue during `glide up`:
```
[INFO] Setting version for github.com/codegangsta/inject to 33e0aa1cb7c019ccc3fbe049a8262a6403d30504.
[ERROR] Dependency /go/src/github.com/emilevauge/traefik/vendor/github.com/docker/docker/autogen/dockerversion failed to resolve: lstat /go/src/github.com/emilevauge/traefik/vendor/github.com/docker/docker/autogen/dockerversion: no such file or directory.
[ERROR] Failed to retrieve a list of dependencies: lstat /go/src/github.com/emilevauge/traefik/vendor/github.com/docker/docker/autogen/dockerversion: no such file or directory
The command '/bin/sh -c glide up' returned a non-zero code: 1
make: *** [build] Error 1
```

cc @vdemeester @ldez 