### PR TITLE
Updated getEscapedName with slash to dash instead of space

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -63,6 +63,7 @@ func replace(s1 string, s2 string, s3 string) string {
 	return strings.Replace(s3, s1, s2, -1)
 }
 
+// Escape beginning slash "/", convert all others to dash "-"
 func getEscapedName(name string) string {
-	return strings.Replace(name, "/", "", -1)
+	return strings.Replace(strings.TrimPrefix(name, "/"), "/", "-", -1)
 }


### PR DESCRIPTION
We already decided to convert all slashes to dashes for marathon deployments, now I'm updating the frontend rule value to also match that.

Currently docker and marathon providers use `getEscapedName`.


Similar effort to #137 

Before:
```
time="2016-02-03T01:01:06Z" level=info msg="Creating frontend frontend-prod-foosvc"
time="2016-02-03T01:01:06Z" level=info msg="Creating route route-host-prod-foosvc Host:prodfoosvc.docker.local"
```
After
```
time="2016-02-03T20:18:55Z" level=info msg="Creating frontend frontend-prod-foosvc"
time="2016-02-03T20:18:55Z" level=info msg="Creating route route-host-prod-foosvc Host:prod-foosvc.docker.local"
```
