### PR TITLE
Bump go 1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ It supports several backends ([Docker :whale:](https://www.docker.com/), [Mesos/
 - SSL frontend support
 - Clean AngularJS Web UI
 - Websocket support
+- HTTP/2 support
 
 ## Demo
 

--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.5.3
+FROM golang:1.6
 
 RUN go get github.com/Masterminds/glide
 RUN go get github.com/mitchellh/gox


### PR DESCRIPTION
This PR bump to go v1.6 and adds native HTTP2 support :)
Fixes #139 